### PR TITLE
fix: better make help do not use uv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ docs: ## Build and serve the documentation
 
 .PHONY: help
 help:
-	@uv run python -c "import re; \
-	[[print(f'\033[36m{m[0]:<20}\033[0m {m[1]}') for m in re.findall(r'^([a-zA-Z_-]+):.*?## (.*)$$', open(makefile).read(), re.M)] for makefile in ('$(MAKEFILE_LIST)').strip().split()]"
+	@awk -F '## ' '/^[A-Za-z_-]+:.*##/ { target = $$1; sub(/:.*/, "", target); printf "\033[36m%-20s\033[0m %s\n", target, $$2 }' $(MAKEFILE_LIST)
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
## Summary

<!-- What does this change do? Keep it short. -->


## Related issues

<!--
Link the tracked issue(s) using the GitHub syntax, e.g. "Closes #123".
If the work only partially addresses an issue, use "Relates to #123".
-->


for now `make help` use uv and install all the package......


## Testing

<!--
List the checks you ran (e.g. `make check`, `make test`, targeted pytest files, manual CLI steps).
Include output snippets when helpful.
-->


## Docs & screenshots

<!--
Note any documentation or example updates included (or explain why none are needed).
Attach screenshots/GIFs when the change affects UX.
-->


## Checklist

- [ ] Conventional Commit title (e.g. `feat:`, `fix:`).
- [ ] Tests cover the change or are not required (explain above).
- [ ] Docs/examples updated when behaviour is user-facing.
- [ ] Schema regenerations (`make gen-all`) are called out if applicable.
