### PR TITLE
feat: Update schema to v0.10.3, support fork_session and resume_session unstable API

### DIFF
--- a/schema/VERSION
+++ b/schema/VERSION
@@ -1,1 +1,1 @@
-refs/tags/v0.9.1
+refs/tags/v0.10.3

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -3,10 +3,12 @@
     "authenticate": "authenticate",
     "initialize": "initialize",
     "session_cancel": "session/cancel",
+    "session_fork": "session/fork",
     "session_list": "session/list",
     "session_load": "session/load",
     "session_new": "session/new",
     "session_prompt": "session/prompt",
+    "session_resume": "session/resume",
     "session_set_mode": "session/set_mode",
     "session_set_model": "session/set_model"
   },
@@ -20,6 +22,9 @@
     "terminal_output": "terminal/output",
     "terminal_release": "terminal/release",
     "terminal_wait_for_exit": "terminal/wait_for_exit"
+  },
+  "protocolMethods": {
+    "cancel_request": "$/cancel_request"
   },
   "version": 1
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -217,6 +217,12 @@
                   "$ref": "#/$defs/ListSessionsResponse"
                 },
                 {
+                  "$ref": "#/$defs/ForkSessionResponse"
+                },
+                {
+                  "$ref": "#/$defs/ResumeSessionResponse"
+                },
+                {
                   "$ref": "#/$defs/SetSessionModeResponse"
                 },
                 {
@@ -529,6 +535,33 @@
       "x-method": "session/cancel",
       "x-side": "agent"
     },
+    "CancelRequestNotification": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNotification to cancel an ongoing request.\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "requestId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RequestId"
+            }
+          ],
+          "description": "The ID of the request to cancel."
+        }
+      },
+      "required": [
+        "requestId"
+      ],
+      "type": "object",
+      "x-method": "$/cancel_request",
+      "x-side": "protocol"
+    },
     "ClientCapabilities": {
       "description": "Capabilities supported by the client.\n\nAdvertised during initialization to inform the agent about\navailable features and methods.\n\nSee protocol docs: [Client Capabilities](https://agentclientprotocol.com/protocol/initialization#client-capabilities)",
       "properties": {
@@ -651,6 +684,22 @@
                     }
                   ],
                   "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nLists existing sessions known to the agent.\n\nThis method is only available if the agent advertises the `listSessions` capability.\n\nThe agent should return metadata about sessions with optional filtering and pagination support."
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ForkSessionRequest"
+                    }
+                  ],
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForks an existing session to create a new independent session.\n\nThis method is only available if the agent advertises the `session.fork` capability.\n\nThe agent should create a new session with the same conversation context as the\noriginal, allowing operations like generating summaries without affecting the\noriginal session's history."
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ResumeSessionRequest"
+                    }
+                  ],
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResumes an existing session without returning previous messages.\n\nThis method is only available if the agent advertises the `session.resume` capability.\n\nThe agent should resume the session context, allowing the conversation to continue\nwithout replaying the message history (unlike `session/load`)."
                 },
                 {
                   "allOf": [
@@ -1126,9 +1175,12 @@
       "description": "JSON-RPC error object.\n\nRepresents an error that occurred during method execution, following the\nJSON-RPC 2.0 error object specification with optional additional data.\n\nSee protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification#error_object)",
       "properties": {
         "code": {
-          "description": "A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification.",
-          "format": "int32",
-          "type": "integer"
+          "allOf": [
+            {
+              "$ref": "#/$defs/ErrorCode"
+            }
+          ],
+          "description": "A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
         },
         "data": {
           "description": "Optional primitive or structured value that contains additional information about the error.\nThis may include debugging information or context-specific details."
@@ -1143,6 +1195,64 @@
         "message"
       ],
       "type": "object"
+    },
+    "ErrorCode": {
+      "anyOf": [
+        {
+          "const": -32700,
+          "description": "**Parse error**: Invalid JSON was received by the server.\nAn error occurred on the server while parsing the JSON text.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32600,
+          "description": "**Invalid request**: The JSON sent is not a valid Request object.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32601,
+          "description": "**Method not found**: The method does not exist or is not available.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32602,
+          "description": "**Invalid params**: Invalid method parameter(s).",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32603,
+          "description": "**Internal error**: Internal JSON-RPC error.\nReserved for implementation-defined server errors.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32800,
+          "description": "**Request cancelled**: **UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nExecution of the method was aborted either due to a cancellation request from the caller or\nbecause of resource constraints or shutdown.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32000,
+          "description": "**Authentication required**: Authentication is required before this operation can be performed.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32002,
+          "description": "**Resource not found**: A given resource, such as a file, was not found.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "description": "Other undefined error code.",
+          "format": "int32",
+          "type": "integer"
+        }
+      ],
+      "description": "Predefined error codes for common JSON-RPC and ACP-specific errors.\n\nThese codes follow the JSON-RPC 2.0 specification for standard errors\nand use the reserved range (-32000 to -32099) for protocol-specific errors."
     },
     "ExtNotification": {
       "description": "Allows the Agent to send an arbitrary notification that is not part of the ACP spec.\nExtension notifications provide a way to send one-way messages for custom functionality\nwhile maintaining protocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)"
@@ -1176,6 +1286,94 @@
         }
       },
       "type": "object"
+    },
+    "ForkSessionRequest": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for forking an existing session.\n\nCreates a new session based on the context of an existing one, allowing\noperations like generating summaries without affecting the original session's history.\n\nOnly available if the Agent supports the `session.fork` capability.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "cwd": {
+          "description": "The working directory for this session.",
+          "type": "string"
+        },
+        "mcpServers": {
+          "description": "List of MCP servers to connect to for this session.",
+          "items": {
+            "$ref": "#/$defs/McpServer"
+          },
+          "type": "array"
+        },
+        "sessionId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ],
+          "description": "The ID of the session to fork."
+        }
+      },
+      "required": [
+        "sessionId",
+        "cwd"
+      ],
+      "type": "object",
+      "x-method": "session/fork",
+      "x-side": "agent"
+    },
+    "ForkSessionResponse": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse from forking an existing session.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "models": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionModelState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+        },
+        "modes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionModeState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+        },
+        "sessionId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ],
+          "description": "Unique identifier for the newly created forked session."
+        }
+      },
+      "required": [
+        "sessionId"
+      ],
+      "type": "object",
+      "x-method": "session/fork",
+      "x-side": "agent"
     },
     "HttpHeader": {
       "description": "An HTTP header to set when making requests to the MCP server.",
@@ -2462,6 +2660,83 @@
       ],
       "type": "object"
     },
+    "ResumeSessionRequest": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for resuming an existing session.\n\nResumes an existing session without returning previous messages (unlike `session/load`).\nThis is useful for agents that can resume sessions but don't implement full session loading.\n\nOnly available if the Agent supports the `session.resume` capability.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "cwd": {
+          "description": "The working directory for this session.",
+          "type": "string"
+        },
+        "mcpServers": {
+          "description": "List of MCP servers to connect to for this session.",
+          "items": {
+            "$ref": "#/$defs/McpServer"
+          },
+          "type": "array"
+        },
+        "sessionId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ],
+          "description": "The ID of the session to resume."
+        }
+      },
+      "required": [
+        "sessionId",
+        "cwd"
+      ],
+      "type": "object",
+      "x-method": "session/resume",
+      "x-side": "agent"
+    },
+    "ResumeSessionResponse": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse from resuming an existing session.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "models": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionModelState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+        },
+        "modes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionModeState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+        }
+      },
+      "type": "object",
+      "x-method": "session/resume",
+      "x-side": "agent"
+    },
     "Role": {
       "description": "The sender or recipient of messages and data in a conversation.",
       "enum": [
@@ -2506,6 +2781,17 @@
             "null"
           ]
         },
+        "fork": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionForkCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`."
+        },
         "list": {
           "anyOf": [
             {
@@ -2516,6 +2802,31 @@
             }
           ],
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/list`."
+        },
+        "resume": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionResumeCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/resume`."
+        }
+      },
+      "type": "object"
+    },
+    "SessionForkCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nBy supplying `{}` it means that the agent supports forking of sessions.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "type": "object"
@@ -2566,6 +2877,34 @@
         "sessionId",
         "cwd"
       ],
+      "type": "object"
+    },
+    "SessionInfoUpdate": {
+      "description": "Update to session metadata. All fields are optional to support partial updates.\n\nAgents send this notification to update session information like title or custom metadata.\nThis allows clients to display dynamic session names and track session state changes.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Human-readable title for the session. Set to null to clear.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updatedAt": {
+          "description": "ISO 8601 timestamp of last activity. Set to null to clear.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
       "type": "object"
     },
     "SessionListCapabilities": {
@@ -2718,6 +3057,20 @@
       "x-method": "session/update",
       "x-side": "client"
     },
+    "SessionResumeCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/resume` method.\n\nBy supplying `{}` it means that the agent supports resuming of sessions.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "SessionUpdate": {
       "description": "Different types of updates that can be sent during session processing.\n\nThese updates provide real-time feedback about the agent's progress.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/prompt-turn#3-agent-reports-output)",
       "discriminator": {
@@ -2860,6 +3213,24 @@
           "properties": {
             "sessionUpdate": {
               "const": "current_mode_update",
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionUpdate"
+          ],
+          "type": "object"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionInfoUpdate"
+            }
+          ],
+          "description": "Session metadata has been updated (title, timestamps, custom metadata)",
+          "properties": {
+            "sessionUpdate": {
+              "const": "session_info_update",
               "type": "string"
             }
           },
@@ -3698,6 +4069,20 @@
         "jsonrpc"
       ],
       "type": "object"
+    },
+    {
+      "anyOf": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/CancelRequestNotification"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)"
+        }
+      ],
+      "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response."
     }
-  ]
+  ],
+  "title": "Agent Client Protocol"
 }

--- a/src/acp/agent/connection.py
+++ b/src/acp/agent/connection.py
@@ -25,6 +25,7 @@ from ..schema import (
     ReleaseTerminalResponse,
     RequestPermissionRequest,
     RequestPermissionResponse,
+    SessionInfoUpdate,
     SessionNotification,
     TerminalOutputRequest,
     TerminalOutputResponse,
@@ -83,7 +84,8 @@ class AgentSideConnection:
         | ToolCallProgress
         | AgentPlanUpdate
         | AvailableCommandsUpdate
-        | CurrentModeUpdate,
+        | CurrentModeUpdate
+        | SessionInfoUpdate,
         **kwargs: Any,
     ) -> None:
         await notify_model(

--- a/src/acp/agent/router.py
+++ b/src/acp/agent/router.py
@@ -9,11 +9,13 @@ from ..router import MessageRouter
 from ..schema import (
     AuthenticateRequest,
     CancelNotification,
+    ForkSessionRequest,
     InitializeRequest,
     ListSessionsRequest,
     LoadSessionRequest,
     NewSessionRequest,
     PromptRequest,
+    ResumeSessionRequest,
     SetSessionModelRequest,
     SetSessionModeRequest,
 )
@@ -58,6 +60,8 @@ def build_agent_router(agent: Agent, use_unstable_protocol: bool = False) -> Mes
         "authenticate",
         adapt_result=normalize_result,
     )
+    router.route_request(AGENT_METHODS["session_fork"], ForkSessionRequest, agent, "fork_session", unstable=True)
+    router.route_request(AGENT_METHODS["session_resume"], ResumeSessionRequest, agent, "resume_session", unstable=True)
 
     router.route_notification(AGENT_METHODS["session_cancel"], CancelNotification, agent, "cancel")
 

--- a/src/acp/client/connection.py
+++ b/src/acp/client/connection.py
@@ -14,6 +14,8 @@ from ..schema import (
     CancelNotification,
     ClientCapabilities,
     EmbeddedResourceContentBlock,
+    ForkSessionRequest,
+    ForkSessionResponse,
     HttpMcpServer,
     ImageContentBlock,
     Implementation,
@@ -29,6 +31,8 @@ from ..schema import (
     PromptRequest,
     PromptResponse,
     ResourceContentBlock,
+    ResumeSessionRequest,
+    ResumeSessionResponse,
     SetSessionModelRequest,
     SetSessionModelResponse,
     SetSessionModeRequest,
@@ -163,6 +167,36 @@ class ClientSideConnection:
             AGENT_METHODS["session_prompt"],
             PromptRequest(prompt=prompt, session_id=session_id, field_meta=kwargs or None),
             PromptResponse,
+        )
+
+    @param_model(ForkSessionRequest)
+    async def fork_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> ForkSessionResponse:
+        return await request_model(
+            self._conn,
+            AGENT_METHODS["session_fork"],
+            ForkSessionRequest(session_id=session_id, cwd=cwd, mcp_servers=mcp_servers, field_meta=kwargs or None),
+            ForkSessionResponse,
+        )
+
+    @param_model(ResumeSessionRequest)
+    async def resume_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> ResumeSessionResponse:
+        return await request_model(
+            self._conn,
+            AGENT_METHODS["session_resume"],
+            ResumeSessionRequest(session_id=session_id, cwd=cwd, mcp_servers=mcp_servers, field_meta=kwargs or None),
+            ResumeSessionResponse,
         )
 
     @param_model(CancelNotification)

--- a/src/acp/interfaces.py
+++ b/src/acp/interfaces.py
@@ -17,6 +17,8 @@ from .schema import (
     CurrentModeUpdate,
     EmbeddedResourceContentBlock,
     EnvVariable,
+    ForkSessionRequest,
+    ForkSessionResponse,
     HttpMcpServer,
     ImageContentBlock,
     Implementation,
@@ -41,6 +43,9 @@ from .schema import (
     RequestPermissionRequest,
     RequestPermissionResponse,
     ResourceContentBlock,
+    ResumeSessionRequest,
+    ResumeSessionResponse,
+    SessionInfoUpdate,
     SessionNotification,
     SetSessionModelRequest,
     SetSessionModelResponse,
@@ -81,7 +86,8 @@ class Client(Protocol):
         | ToolCallProgress
         | AgentPlanUpdate
         | AvailableCommandsUpdate
-        | CurrentModeUpdate,
+        | CurrentModeUpdate
+        | SessionInfoUpdate,
         **kwargs: Any,
     ) -> None: ...
 
@@ -181,6 +187,24 @@ class Agent(Protocol):
         session_id: str,
         **kwargs: Any,
     ) -> PromptResponse: ...
+
+    @param_model(ForkSessionRequest)
+    async def fork_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> ForkSessionResponse: ...
+
+    @param_model(ResumeSessionRequest)
+    async def resume_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> ResumeSessionResponse: ...
 
     @param_model(CancelNotification)
     async def cancel(self, session_id: str, **kwargs: Any) -> None: ...

--- a/src/acp/meta.py
+++ b/src/acp/meta.py
@@ -1,13 +1,15 @@
 # Generated from schema/meta.json. Do not edit by hand.
-# Schema ref: refs/tags/v0.9.1
+# Schema ref: refs/tags/v0.10.3
 AGENT_METHODS = {
     "authenticate": "authenticate",
     "initialize": "initialize",
     "session_cancel": "session/cancel",
+    "session_fork": "session/fork",
     "session_list": "session/list",
     "session_load": "session/load",
     "session_new": "session/new",
     "session_prompt": "session/prompt",
+    "session_resume": "session/resume",
     "session_set_mode": "session/set_mode",
     "session_set_model": "session/set_model",
 }

--- a/src/acp/schema.py
+++ b/src/acp/schema.py
@@ -1,5 +1,5 @@
 # Generated from schema/schema.json. Do not edit by hand.
-# Schema ref: refs/tags/v0.9.1
+# Schema ref: refs/tags/v0.10.3
 
 from __future__ import annotations
 
@@ -175,33 +175,6 @@ class EnvVariable(BaseModel):
     name: Annotated[str, Field(description="The name of the environment variable.")]
     # The value to set for the environment variable.
     value: Annotated[str, Field(description="The value to set for the environment variable.")]
-
-
-class Error(BaseModel):
-    # A number indicating the error type that occurred.
-    # This must be an integer as defined in the JSON-RPC specification.
-    code: Annotated[
-        int,
-        Field(
-            description="A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
-        ),
-    ]
-    # Optional primitive or structured value that contains additional information about the error.
-    # This may include debugging information or context-specific details.
-    data: Annotated[
-        Optional[Any],
-        Field(
-            description="Optional primitive or structured value that contains additional information about the error.\nThis may include debugging information or context-specific details."
-        ),
-    ] = None
-    # A string providing a short description of the error.
-    # The message should be limited to a concise single sentence.
-    message: Annotated[
-        str,
-        Field(
-            description="A string providing a short description of the error.\nThe message should be limited to a concise single sentence."
-        ),
-    ]
 
 
 class FileSystemCapability(BaseModel):
@@ -544,6 +517,21 @@ class SelectedPermissionOutcome(BaseModel):
     ]
 
 
+class SessionForkCapabilities(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+
+
 class SessionInfo(BaseModel):
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
     # metadata to their interactions. Implementations MUST NOT make assumptions about values at
@@ -570,6 +558,34 @@ class SessionInfo(BaseModel):
     updated_at: Annotated[
         Optional[str],
         Field(alias="updatedAt", description="ISO 8601 timestamp of last activity"),
+    ] = None
+
+
+class _SessionInfoUpdate(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+    # Human-readable title for the session. Set to null to clear.
+    title: Annotated[
+        Optional[str],
+        Field(description="Human-readable title for the session. Set to null to clear."),
+    ] = None
+    # ISO 8601 timestamp of last activity. Set to null to clear.
+    updated_at: Annotated[
+        Optional[str],
+        Field(
+            alias="updatedAt",
+            description="ISO 8601 timestamp of last activity. Set to null to clear.",
+        ),
     ] = None
 
 
@@ -614,6 +630,25 @@ class SessionModelState(BaseModel):
         str,
         Field(alias="currentModelId", description="The current model the Agent is in."),
     ]
+
+
+class SessionResumeCapabilities(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+
+
+class SessionInfoUpdate(_SessionInfoUpdate):
+    session_update: Annotated[Literal["session_info_update"], Field(alias="sessionUpdate")]
 
 
 class SetSessionModeRequest(BaseModel):
@@ -922,25 +957,6 @@ class WriteTextFileResponse(BaseModel):
     ] = None
 
 
-class AgentErrorMessage(BaseModel):
-    error: Error
-    # JSON RPC Request Id
-    #
-    # An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]
-    #
-    # The Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.
-    #
-    # [1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.
-    #
-    # [2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions.
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(
-            description="JSON RPC Request Id\n\nAn identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]\n\nThe Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.\n\n[1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.\n\n[2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions."
-        ),
-    ] = None
-
-
 class Annotations(BaseModel):
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
     # metadata to their interactions. Implementations MUST NOT make assumptions about values at
@@ -1008,6 +1024,26 @@ class CancelNotification(BaseModel):
     ]
 
 
+class CancelRequestNotification(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+    # The ID of the request to cancel.
+    request_id: Annotated[
+        Optional[Union[int, str]],
+        Field(alias="requestId", description="The ID of the request to cancel."),
+    ] = None
+
+
 class ClientCapabilities(BaseModel):
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
     # metadata to their interactions. Implementations MUST NOT make assumptions about values at
@@ -1039,25 +1075,6 @@ class ClientCapabilities(BaseModel):
 class ClientNotification(BaseModel):
     method: str
     params: Optional[Union[CancelNotification, Any]] = None
-
-
-class ClientErrorMessage(BaseModel):
-    error: Error
-    # JSON RPC Request Id
-    #
-    # An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]
-    #
-    # The Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.
-    #
-    # [1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.
-    #
-    # [2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions.
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(
-            description="JSON RPC Request Id\n\nAn identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]\n\nThe Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.\n\n[1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.\n\n[2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions."
-        ),
-    ] = None
 
 
 class AudioContentBlock(AudioContent):
@@ -1111,7 +1128,7 @@ class CreateTerminalRequest(BaseModel):
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
 
 
-class CurrentModeUpdate(BaseModel):
+class _CurrentModeUpdate(BaseModel):
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
     # metadata to their interactions. Implementations MUST NOT make assumptions about values at
     # these keys.
@@ -1126,6 +1143,33 @@ class CurrentModeUpdate(BaseModel):
     ] = None
     # The ID of the current mode
     current_mode_id: Annotated[str, Field(alias="currentModeId", description="The ID of the current mode")]
+
+
+class Error(BaseModel):
+    # A number indicating the error type that occurred.
+    # This must be an integer as defined in the JSON-RPC specification.
+    code: Annotated[
+        int,
+        Field(
+            description="A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
+        ),
+    ]
+    # Optional primitive or structured value that contains additional information about the error.
+    # This may include debugging information or context-specific details.
+    data: Annotated[
+        Optional[Any],
+        Field(
+            description="Optional primitive or structured value that contains additional information about the error.\nThis may include debugging information or context-specific details."
+        ),
+    ] = None
+    # A string providing a short description of the error.
+    # The message should be limited to a concise single sentence.
+    message: Annotated[
+        str,
+        Field(
+            description="A string providing a short description of the error.\nThe message should be limited to a concise single sentence."
+        ),
+    ]
 
 
 class ImageContent(BaseModel):
@@ -1445,6 +1489,33 @@ class ResourceLink(BaseModel):
     uri: str
 
 
+class ResumeSessionRequest(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+    # The working directory for this session.
+    cwd: Annotated[str, Field(description="The working directory for this session.")]
+    # List of MCP servers to connect to for this session.
+    mcp_servers: Annotated[
+        Optional[List[Union[HttpMcpServer, SseMcpServer, McpServerStdio]]],
+        Field(
+            alias="mcpServers",
+            description="List of MCP servers to connect to for this session.",
+        ),
+    ] = None
+    # The ID of the session to resume.
+    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to resume.")]
+
+
 class SessionCapabilities(BaseModel):
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
     # metadata to their interactions. Implementations MUST NOT make assumptions about values at
@@ -1462,11 +1533,33 @@ class SessionCapabilities(BaseModel):
     #
     # This capability is not part of the spec yet, and may be removed or changed at any point.
     #
+    # Whether the agent supports `session/fork`.
+    fork: Annotated[
+        Optional[SessionForkCapabilities],
+        Field(
+            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`."
+        ),
+    ] = None
+    # **UNSTABLE**
+    #
+    # This capability is not part of the spec yet, and may be removed or changed at any point.
+    #
     # Whether the agent supports `session/list`.
     list: Annotated[
         Optional[SessionListCapabilities],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/list`."
+        ),
+    ] = None
+    # **UNSTABLE**
+    #
+    # This capability is not part of the spec yet, and may be removed or changed at any point.
+    #
+    # Whether the agent supports `session/resume`.
+    resume: Annotated[
+        Optional[SessionResumeCapabilities],
+        Field(
+            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/resume`."
         ),
     ] = None
 
@@ -1518,7 +1611,7 @@ class SessionModeState(BaseModel):
     ]
 
 
-class CurrentModeUpdate(CurrentModeUpdate):
+class CurrentModeUpdate(_CurrentModeUpdate):
     session_update: Annotated[Literal["current_mode_update"], Field(alias="sessionUpdate")]
 
 
@@ -1581,6 +1674,25 @@ class AgentCapabilities(BaseModel):
     )
 
 
+class AgentErrorMessage(BaseModel):
+    error: Error
+    # JSON RPC Request Id
+    #
+    # An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]
+    #
+    # The Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.
+    #
+    # [1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.
+    #
+    # [2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions.
+    id: Annotated[
+        Optional[Union[int, str]],
+        Field(
+            description="JSON RPC Request Id\n\nAn identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]\n\nThe Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.\n\n[1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.\n\n[2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions."
+        ),
+    ] = None
+
+
 class AvailableCommand(BaseModel):
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
     # metadata to their interactions. Implementations MUST NOT make assumptions about values at
@@ -1608,7 +1720,7 @@ class AvailableCommand(BaseModel):
     ]
 
 
-class AvailableCommandsUpdate(BaseModel):
+class _AvailableCommandsUpdate(BaseModel):
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
     # metadata to their interactions. Implementations MUST NOT make assumptions about values at
     # these keys.
@@ -1668,6 +1780,25 @@ class ClientResponseMessage(BaseModel):
     ]
 
 
+class ClientErrorMessage(BaseModel):
+    error: Error
+    # JSON RPC Request Id
+    #
+    # An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]
+    #
+    # The Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.
+    #
+    # [1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.
+    #
+    # [2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions.
+    id: Annotated[
+        Optional[Union[int, str]],
+        Field(
+            description="JSON RPC Request Id\n\nAn identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]\n\nThe Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.\n\n[1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.\n\n[2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions."
+        ),
+    ] = None
+
+
 class ClientResponse(RootModel[Union[ClientResponseMessage, ClientErrorMessage]]):
     root: Union[ClientResponseMessage, ClientErrorMessage]
 
@@ -1702,6 +1833,76 @@ class EmbeddedResource(BaseModel):
     resource: Annotated[
         Union[TextResourceContents, BlobResourceContents],
         Field(description="Resource content that can be embedded in a message."),
+    ]
+
+
+class ForkSessionRequest(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+    # The working directory for this session.
+    cwd: Annotated[str, Field(description="The working directory for this session.")]
+    # List of MCP servers to connect to for this session.
+    mcp_servers: Annotated[
+        Optional[List[Union[HttpMcpServer, SseMcpServer, McpServerStdio]]],
+        Field(
+            alias="mcpServers",
+            description="List of MCP servers to connect to for this session.",
+        ),
+    ] = None
+    # The ID of the session to fork.
+    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to fork.")]
+
+
+class ForkSessionResponse(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+    # **UNSTABLE**
+    #
+    # This capability is not part of the spec yet, and may be removed or changed at any point.
+    #
+    # Initial model state if supported by the Agent
+    models: Annotated[
+        Optional[SessionModelState],
+        Field(
+            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+        ),
+    ] = None
+    # Initial mode state if supported by the Agent
+    #
+    # See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
+    modes: Annotated[
+        Optional[SessionModeState],
+        Field(
+            description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+        ),
+    ] = None
+    # Unique identifier for the newly created forked session.
+    session_id: Annotated[
+        str,
+        Field(
+            alias="sessionId",
+            description="Unique identifier for the newly created forked session.",
+        ),
     ]
 
 
@@ -1891,11 +2092,46 @@ class Plan(BaseModel):
     ]
 
 
+class ResumeSessionResponse(BaseModel):
+    # The _meta property is reserved by ACP to allow clients and agents to attach additional
+    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    # these keys.
+    #
+    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    field_meta: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            alias="_meta",
+            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+        ),
+    ] = None
+    # **UNSTABLE**
+    #
+    # This capability is not part of the spec yet, and may be removed or changed at any point.
+    #
+    # Initial model state if supported by the Agent
+    models: Annotated[
+        Optional[SessionModelState],
+        Field(
+            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+        ),
+    ] = None
+    # Initial mode state if supported by the Agent
+    #
+    # See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
+    modes: Annotated[
+        Optional[SessionModeState],
+        Field(
+            description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+        ),
+    ] = None
+
+
 class AgentPlanUpdate(Plan):
     session_update: Annotated[Literal["plan"], Field(alias="sessionUpdate")]
 
 
-class AvailableCommandsUpdate(AvailableCommandsUpdate):
+class AvailableCommandsUpdate(_AvailableCommandsUpdate):
     session_update: Annotated[Literal["available_commands_update"], Field(alias="sessionUpdate")]
 
 
@@ -1928,6 +2164,8 @@ class AgentResponseMessage(BaseModel):
             NewSessionResponse,
             LoadSessionResponse,
             ListSessionsResponse,
+            ForkSessionResponse,
+            ResumeSessionResponse,
             SetSessionModeResponse,
             PromptResponse,
             SetSessionModelResponse,
@@ -2055,6 +2293,8 @@ class ClientRequest(BaseModel):
             NewSessionRequest,
             LoadSessionRequest,
             ListSessionsRequest,
+            ForkSessionRequest,
+            ResumeSessionRequest,
             SetSessionModeRequest,
             PromptRequest,
             SetSessionModelRequest,
@@ -2290,6 +2530,7 @@ class SessionNotification(BaseModel):
             AgentPlanUpdate,
             AvailableCommandsUpdate,
             CurrentModeUpdate,
+            SessionInfoUpdate,
         ],
         Field(description="The actual update content.", discriminator="session_update"),
     ]
@@ -2322,6 +2563,7 @@ SessionUpdate5 = ToolCallProgress
 SessionUpdate6 = AgentPlanUpdate
 SessionUpdate7 = AvailableCommandsUpdate
 SessionUpdate8 = CurrentModeUpdate
+SessionUpdate9 = SessionInfoUpdate
 ToolCallContent1 = ContentToolCallContent
 ToolCallContent2 = FileEditToolCallContent
 ToolCallContent3 = TerminalToolCallContent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ from acp import (
     RequestError,
     RequestPermissionResponse,
     SessionNotification,
-    SetSessionModelResponse,
     SetSessionModeResponse,
     TerminalOutputResponse,
     WaitForTerminalExitResponse,
@@ -42,7 +41,6 @@ from acp.schema import (
     HttpMcpServer,
     ImageContentBlock,
     Implementation,
-    ListSessionsResponse,
     McpServerStdio,
     PermissionOption,
     ResourceContentBlock,
@@ -246,11 +244,6 @@ class TestAgent:
     ) -> LoadSessionResponse | None:
         return LoadSessionResponse()
 
-    async def list_sessions(
-        self, cursor: str | None = None, cwd: str | None = None, **kwargs: Any
-    ) -> ListSessionsResponse:
-        return ListSessionsResponse(sessions=[], next_cursor=None)
-
     async def authenticate(self, method_id: str, **kwargs: Any) -> AuthenticateResponse | None:
         return AuthenticateResponse()
 
@@ -274,9 +267,6 @@ class TestAgent:
 
     async def set_session_mode(self, mode_id: str, session_id: str, **kwargs: Any) -> SetSessionModeResponse | None:
         return SetSessionModeResponse()
-
-    async def set_session_model(self, model_id: str, session_id: str, **kwargs: Any) -> SetSessionModelResponse | None:
-        return SetSessionModelResponse()
 
     async def ext_method(self, method: str, params: dict) -> dict:
         self.ext_calls.append((method, params))

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -24,7 +24,6 @@ from acp import (
     update_agent_message_text,
     update_tool_call,
 )
-from acp.exceptions import RequestError
 from acp.schema import (
     AgentMessageChunk,
     AllowedOutcome,
@@ -35,11 +34,9 @@ from acp.schema import (
     HttpMcpServer,
     ImageContentBlock,
     Implementation,
-    ListSessionsResponse,
     McpServerStdio,
     PermissionOption,
     ResourceContentBlock,
-    SetSessionModelResponse,
     SseMcpServer,
     TextContentBlock,
     ToolCallLocation,
@@ -72,10 +69,6 @@ async def test_initialize_and_new_session(connect):
 
     mode_resp = await agent_conn.set_session_mode(session_id=new_sess.session_id, mode_id="ask")
     assert isinstance(mode_resp, SetSessionModeResponse)
-
-    with pytest.raises(RequestError), pytest.warns(UserWarning) as record:
-        await agent_conn.set_session_model(session_id=new_sess.session_id, model_id="gpt-4o")
-        assert len(record) == 1
 
 
 @pytest.mark.asyncio
@@ -190,10 +183,6 @@ async def test_set_session_mode_and_extensions(connect, agent, client):
     # setSessionMode
     resp = await agent_conn.set_session_mode(session_id="sess", mode_id="yolo")
     assert isinstance(resp, SetSessionModeResponse)
-
-    with pytest.raises(RequestError), pytest.warns(UserWarning) as record:
-        await agent_conn.set_session_model(session_id="sess", model_id="gpt-4o-mini")
-        assert len(record) == 1
 
     # extMethod
     echo = await agent_conn.ext_method("example.com/echo", {"x": 1})
@@ -432,14 +421,3 @@ async def test_spawn_agent_process_roundtrip(tmp_path):
         assert test_client.notifications
 
     assert process.returncode is not None
-
-
-@pytest.mark.asyncio
-async def test_call_unstable_protocol(connect):
-    _, agent_conn = connect(use_unstable_protocol=True)
-
-    resp = await agent_conn.list_sessions()
-    assert isinstance(resp, ListSessionsResponse)
-
-    resp = await agent_conn.set_session_model(session_id="sess", model_id="gpt-4o-mini")
-    assert isinstance(resp, SetSessionModelResponse)

--- a/tests/test_unstable.py
+++ b/tests/test_unstable.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+import pytest
+
+from acp.exceptions import RequestError
+from acp.schema import (
+    ForkSessionResponse,
+    HttpMcpServer,
+    ListSessionsResponse,
+    McpServerStdio,
+    ResumeSessionResponse,
+    SetSessionModelResponse,
+    SseMcpServer,
+)
+from tests.conftest import TestAgent
+
+
+class UnstableAgent(TestAgent):
+    async def list_sessions(self, cursor: str | None = None, cwd: str | None = None, **kwargs) -> ListSessionsResponse:
+        return ListSessionsResponse(sessions=[])
+
+    async def set_session_model(self, model_id: str, session_id: str, **kwargs: Any) -> SetSessionModelResponse | None:
+        return SetSessionModelResponse()
+
+    async def fork_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> ForkSessionResponse:
+        return ForkSessionResponse(session_id="forked_sess")
+
+    async def resume_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> ResumeSessionResponse:
+        return ResumeSessionResponse()
+
+
+@pytest.mark.parametrize("agent", [UnstableAgent()])
+@pytest.mark.asyncio
+async def test_call_unstable_protocol(connect):
+    _, agent_conn = connect(use_unstable_protocol=True)
+
+    resp = await agent_conn.list_sessions()
+    assert isinstance(resp, ListSessionsResponse)
+
+    resp = await agent_conn.set_session_model(session_id="sess", model_id="gpt-4o-mini")
+    assert isinstance(resp, SetSessionModelResponse)
+
+    resp = await agent_conn.fork_session(cwd="/workspace", session_id="sess")
+    assert isinstance(resp, ForkSessionResponse)
+
+    resp = await agent_conn.resume_session(cwd="/workspace", session_id="sess")
+    assert isinstance(resp, ResumeSessionResponse)
+
+
+@pytest.mark.parametrize("agent", [UnstableAgent()])
+@pytest.mark.asyncio
+async def test_call_unstable_protocol_warning(connect):
+    _, agent_conn = connect(use_unstable_protocol=False)
+
+    with pytest.warns(UserWarning) as record:
+        with pytest.raises(RequestError):
+            await agent_conn.list_sessions()
+        assert len(record) == 1
+
+    with pytest.warns(UserWarning) as record:
+        with pytest.raises(RequestError):
+            await agent_conn.set_session_model(session_id="sess", model_id="gpt-4o-mini")
+        assert len(record) == 1


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## Summary

<!-- What does this change do? Keep it short. -->


## Related issues

<!--
Link the tracked issue(s) using the GitHub syntax, e.g. "Closes #123".
If the work only partially addresses an issue, use "Relates to #123".
-->


## Testing

<!--
List the checks you ran (e.g. `make check`, `make test`, targeted pytest files, manual CLI steps).
Include output snippets when helpful.
-->


## Docs & screenshots

<!--
Note any documentation or example updates included (or explain why none are needed).
Attach screenshots/GIFs when the change affects UX.
-->


## Checklist

- [x] Conventional Commit title (e.g. `feat:`, `fix:`).
- [x] Tests cover the change or are not required (explain above).
- [ ] Docs/examples updated when behaviour is user-facing.
- [x] Schema regenerations (`make gen-all`) are called out if applicable.
