### PR TITLE
docs: Add missing prop to settings.json in ACP quickstart, add uv example

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -50,12 +50,28 @@ Add an Agent Server entry in `settings.json` (Zed → Settings → Agents panel)
 {
   "agent_servers": {
     "Echo Agent (Python)": {
+      "type": "custom",
       "command": "/abs/path/to/python",
       "args": [
         "/abs/path/to/agentclientprotocol/python-sdk/examples/echo_agent.py"
       ]
     }
   }
+}
+```
+
+Or, if using `uv`:
+
+```json
+{
+  "agent_servers": {
+      "type": "custom",
+      "command": "uv",
+      "args": [
+        "run",
+        "/abs/path/to/agentclientprotocol/python-sdk/examples/echo_agent.py"
+      ],
+    }
 }
 ```
 


### PR DESCRIPTION
## Summary

While going through the quickstart, my editor complained about a missing `"type"` field. I also struggled for a minute to come up with the right command since I'm using `uv`


## Related issues

<!--
Link the tracked issue(s) using the GitHub syntax, e.g. "Closes #123".
If the work only partially addresses an issue, use "Relates to #123".
-->


## Testing

Just a markdown file change

## Docs & screenshots

Just a markdown file change

## Checklist

- [x] Conventional Commit title (e.g. `feat:`, `fix:`).
- [x] Tests cover the change or are not required (explain above).
- [x] Docs/examples updated when behaviour is user-facing.
- [x] Schema regenerations (`make gen-all`) are called out if applicable.
