### PR TITLE
fix: allow omitting mcpServers in session requests

### DIFF
--- a/src/acp/client/connection.py
+++ b/src/acp/client/connection.py
@@ -93,23 +93,31 @@ class ClientSideConnection:
 
     @param_model(NewSessionRequest)
     async def new_session(
-        self, cwd: str, mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio], **kwargs: Any
+        self, cwd: str, mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None, **kwargs: Any
     ) -> NewSessionResponse:
+        resolved_mcp_servers = mcp_servers or []
         return await request_model(
             self._conn,
             AGENT_METHODS["session_new"],
-            NewSessionRequest(cwd=cwd, mcp_servers=mcp_servers, field_meta=kwargs or None),
+            NewSessionRequest(cwd=cwd, mcp_servers=resolved_mcp_servers, field_meta=kwargs or None),
             NewSessionResponse,
         )
 
     @param_model(LoadSessionRequest)
     async def load_session(
-        self, cwd: str, mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio], session_id: str, **kwargs: Any
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
     ) -> LoadSessionResponse:
+        resolved_mcp_servers = mcp_servers or []
         return await request_model_from_dict(
             self._conn,
             AGENT_METHODS["session_load"],
-            LoadSessionRequest(cwd=cwd, mcp_servers=mcp_servers, session_id=session_id, field_meta=kwargs or None),
+            LoadSessionRequest(
+                cwd=cwd, mcp_servers=resolved_mcp_servers, session_id=session_id, field_meta=kwargs or None
+            ),
             LoadSessionResponse,
         )
 

--- a/src/acp/interfaces.py
+++ b/src/acp/interfaces.py
@@ -154,12 +154,16 @@ class Agent(Protocol):
 
     @param_model(NewSessionRequest)
     async def new_session(
-        self, cwd: str, mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio], **kwargs: Any
+        self, cwd: str, mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None, **kwargs: Any
     ) -> NewSessionResponse: ...
 
     @param_model(LoadSessionRequest)
     async def load_session(
-        self, cwd: str, mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio], session_id: str, **kwargs: Any
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
     ) -> LoadSessionResponse | None: ...
 
     @param_model(ListSessionsRequest)

--- a/tests/real_user/test_mcp_servers_optional.py
+++ b/tests/real_user/test_mcp_servers_optional.py
@@ -1,0 +1,68 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from acp import InitializeResponse, LoadSessionResponse, NewSessionResponse
+from acp.core import AgentSideConnection, ClientSideConnection
+from acp.schema import HttpMcpServer, McpServerStdio, SseMcpServer
+from tests.conftest import TestAgent, TestClient
+
+
+class McpOptionalAgent(TestAgent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_new_session: tuple[str, Any] | None = None
+        self.seen_load_session: tuple[str, str, Any] | None = None
+
+    async def new_session(
+        self,
+        cwd: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        resolved_mcp_servers = mcp_servers or []
+        self.seen_new_session = (cwd, resolved_mcp_servers)
+        return await super().new_session(cwd=cwd, mcp_servers=resolved_mcp_servers, **kwargs)
+
+    async def load_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        **kwargs: Any,
+    ) -> LoadSessionResponse | None:
+        resolved_mcp_servers = mcp_servers or []
+        self.seen_load_session = (cwd, session_id, resolved_mcp_servers)
+        return await super().load_session(cwd=cwd, session_id=session_id, mcp_servers=resolved_mcp_servers, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_session_requests_default_empty_mcp_servers(server) -> None:
+    client = TestClient()
+    captured_agent: list[McpOptionalAgent] = []
+
+    agent_conn = ClientSideConnection(client, server._client_writer, server._client_reader)  # type: ignore[arg-type]
+    _agent_side = AgentSideConnection(
+        lambda _conn: captured_agent.append(McpOptionalAgent()) or captured_agent[-1],
+        server._server_writer,
+        server._server_reader,
+        listening=True,
+    )
+
+    init = await asyncio.wait_for(agent_conn.initialize(protocol_version=1), timeout=1.0)
+    assert isinstance(init, InitializeResponse)
+
+    new_session = await asyncio.wait_for(agent_conn.new_session(cwd="/workspace"), timeout=1.0)
+    assert isinstance(new_session, NewSessionResponse)
+
+    load_session = await asyncio.wait_for(
+        agent_conn.load_session(cwd="/workspace", session_id=new_session.session_id),
+        timeout=1.0,
+    )
+    assert isinstance(load_session, LoadSessionResponse)
+
+    assert captured_agent, "Agent was not constructed"
+    [agent] = captured_agent
+    assert agent.seen_new_session == ("/workspace", [])
+    assert agent.seen_load_session == ("/workspace", new_session.session_id, [])


### PR DESCRIPTION
## Summary

Allow clients to omit `mcpServers` in `NewSessionRequest` and `LoadSessionRequest` without triggering Pydantic validation errors.

This keeps the Python SDK aligned with the protocol expectation from issue #55 while the upstream schema continues to mark the field as required.

## Related issues

Closes #55

## Testing

- `make check`
- `make test`

## Docs & screenshots

- None.

## Checklist

- [x] Conventional Commit title (e.g. `feat:`, `fix:`).
- [x] Tests cover the change or are not required (explain above).
- [x] Docs/examples updated when behaviour is user-facing.
- [x] Schema regenerations (`make gen-all`) are called out if applicable.
