### PR TITLE
fix: Add SessionInfoUpdate to SessionUpdate type in helpers

### DIFF
--- a/src/acp/helpers.py
+++ b/src/acp/helpers.py
@@ -20,6 +20,7 @@ from .schema import (
     PlanEntryPriority,
     PlanEntryStatus,
     ResourceContentBlock,
+    SessionInfoUpdate,
     SessionNotification,
     TerminalToolCallContent,
     TextContentBlock,


### PR DESCRIPTION
## Summary

The `SessionUpdate` type in helpers is inconsistent with the type of the `update` arg in `Client.session_update`, missing `SessionInfoUpdate` variant. I assume the helpers should align to the Client Protocol, so I add the missing variant into helpers.


## Related issues

<!--
Link the tracked issue(s) using the GitHub syntax, e.g. "Closes #123".
If the work only partially addresses an issue, use "Relates to #123".
-->


## Testing

<!--
List the checks you ran (e.g. `make check`, `make test`, targeted pytest files, manual CLI steps).
Include output snippets when helpful.
-->


## Docs & screenshots

<!--
Note any documentation or example updates included (or explain why none are needed).
Attach screenshots/GIFs when the change affects UX.
-->


## Checklist

- [x] Conventional Commit title (e.g. `feat:`, `fix:`).
- [x] Tests cover the change or are not required (explain above).
- [x] Docs/examples updated when behaviour is user-facing.
- [x] Schema regenerations (`make gen-all`) are called out if applicable.
