### PR TITLE
fix: reject pending requests on EOF to prevent infinite hang

### DIFF
--- a/src/acp/connection.py
+++ b/src/acp/connection.py
@@ -160,6 +160,14 @@ class Connection:
                 await self._process_message(message)
         except asyncio.CancelledError:
             return
+        # EOF: the remote end closed the connection.  Reject any in-flight
+        # outgoing requests so their callers receive an error instead of
+        # hanging forever.  Without this, a subprocess crash during
+        # initialize() or new_session() silently converts into an infinite
+        # hang because _on_receive_error is only invoked on exceptions.
+        self._state.reject_all_outgoing(
+            ConnectionError("Connection closed: remote end sent EOF")
+        )
 
     async def _process_message(self, message: dict[str, Any]) -> None:
         method = message.get("method")

--- a/src/acp/connection.py
+++ b/src/acp/connection.py
@@ -83,6 +83,7 @@ class Connection:
         self._tasks.add_error_handler(self._on_task_error)
         self._queue = queue or InMemoryMessageQueue()
         self._closed = False
+        self._disconnected = False
         self._sender = (sender_factory or self._default_sender_factory)(self._writer, self._tasks)
         if listening:
             self._recv_task = self._tasks.create(
@@ -132,6 +133,7 @@ class Connection:
         self._observers.append(observer)
 
     async def send_request(self, method: str, params: JsonValue | None = None) -> Any:
+        self._raise_if_unavailable()
         request_id = self._next_request_id
         self._next_request_id += 1
         future = self._state.register_outgoing(request_id, method)
@@ -141,6 +143,7 @@ class Connection:
         return await future
 
     async def send_notification(self, method: str, params: JsonValue | None = None) -> None:
+        self._raise_if_unavailable()
         payload = {"jsonrpc": "2.0", "method": method, "params": params}
         await self._sender.send(payload)
         self._notify_observers(StreamDirection.OUTGOING, payload)
@@ -160,14 +163,7 @@ class Connection:
                 await self._process_message(message)
         except asyncio.CancelledError:
             return
-        # EOF: the remote end closed the connection.  Reject any in-flight
-        # outgoing requests so their callers receive an error instead of
-        # hanging forever.  Without this, a subprocess crash during
-        # initialize() or new_session() silently converts into an infinite
-        # hang because _on_receive_error is only invoked on exceptions.
-        self._state.reject_all_outgoing(
-            ConnectionError("Connection closed: remote end sent EOF")
-        )
+        self._disconnect()
 
     async def _process_message(self, message: dict[str, Any]) -> None:
         method = message.get("method")
@@ -270,7 +266,7 @@ class Connection:
 
     def _on_receive_error(self, task: asyncio.Task[Any], exc: BaseException) -> None:
         logging.exception("Receive loop failed", exc_info=exc)
-        self._state.reject_all_outgoing(exc)
+        self._disconnect()
 
     def _on_task_error(self, task: asyncio.Task[Any], exc: BaseException) -> None:
         logging.exception("Background task failed", exc_info=exc)
@@ -293,3 +289,13 @@ class Connection:
 
     def _default_sender_factory(self, writer: asyncio.StreamWriter, supervisor: TaskSupervisor) -> MessageSender:
         return MessageSender(writer, supervisor)
+
+    def _disconnect(self) -> None:
+        if self._disconnected:
+            return
+        self._disconnected = True
+        self._state.reject_all_outgoing(ConnectionError("Connection closed"))
+
+    def _raise_if_unavailable(self) -> None:
+        if self._disconnected or self._closed:
+            raise ConnectionError("Connection closed")

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -26,6 +26,7 @@ from acp import (
     update_agent_message_text,
     update_tool_call,
 )
+from acp.connection import Connection
 from acp.core import AgentSideConnection, ClientSideConnection
 from acp.schema import (
     AgentMessageChunk,
@@ -197,6 +198,35 @@ async def test_concurrent_reads(connect, client):
     results = await asyncio.gather(*(read_one(i) for i in range(5)))
     for i, res in enumerate(results):
         assert res.content == f"Content {i}"
+
+
+@pytest.mark.asyncio
+async def test_pending_request_fails_when_remote_sends_eof(server):
+    conn = Connection(lambda method, params, is_notification: None, server.client_writer, server.client_reader)
+    request = asyncio.create_task(conn.send_request("ping", {"value": 1}))
+
+    await asyncio.sleep(0.05)
+    server.server_writer.close()
+    await server.server_writer.wait_closed()
+
+    with pytest.raises(ConnectionError, match="Connection closed"):
+        await asyncio.wait_for(request, timeout=1.0)
+
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_new_requests_fail_fast_after_remote_eof(server):
+    conn = Connection(lambda method, params, is_notification: None, server.client_writer, server.client_reader)
+
+    server.server_writer.close()
+    await server.server_writer.wait_closed()
+    await asyncio.sleep(0.05)
+
+    with pytest.raises(ConnectionError, match="Connection closed"):
+        await asyncio.wait_for(conn.send_request("ping", {"value": 1}), timeout=1.0)
+
+    await conn.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When the remote end closes the connection (e.g., an ACP subprocess crashes on startup), `_receive_loop` exits cleanly on EOF without raising an exception. Since `TaskSupervisor._on_done` only calls `on_error` for exceptions, `_on_receive_error` is never invoked and `_state.reject_all_outgoing()` is never called. Any in-flight `send_request()` futures hang **forever**.

This adds a `reject_all_outgoing()` call after the receive loop breaks on EOF, so callers get a `ConnectionError` instead of an infinite hang.

## Test plan

- [ ] Verify existing tests pass
- [ ] Verify that when a subprocess crashes mid-request, the caller receives `ConnectionError("Connection closed: remote end sent EOF")` instead of hanging

Fixes #85