### PR TITLE
fix: skip blank/whitespace lines in receive loop

### DIFF
--- a/src/acp/connection.py
+++ b/src/acp/connection.py
@@ -151,6 +151,9 @@ class Connection:
                 line = await self._reader.readline()
                 if not line:
                     break
+                line = line.strip()
+                if not line:
+                    continue
                 try:
                     message: dict[str, Any] = json.loads(line)
                 except Exception:

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -316,6 +316,20 @@ async def test_ignore_invalid_messages(connect, server):
         await asyncio.wait_for(server.client_reader.readline(), timeout=0.1)
 
 
+@pytest.mark.asyncio
+async def test_blank_lines_skipped(connect, server):
+    connect(connect_agent=True, connect_client=False)
+
+    for noise in [b"\n", b"  \n", b"\r\n"]:
+        server.client_writer.write(noise)
+    req = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 1}}
+    server.client_writer.write((json.dumps(req) + "\n").encode())
+    await server.client_writer.drain()
+
+    resp = json.loads(await asyncio.wait_for(server.client_reader.readline(), timeout=1))
+    assert resp["id"] == 1 and "result" in resp
+
+
 class _ExampleAgent(Agent):
     __test__ = False
 


### PR DESCRIPTION
## Summary

Blank/whitespace-only lines (`\n`, `\r\n`, `  \n`) in the stream are valid no-ops in newline-delimited JSON framing but currently reach `json.loads()` and trigger a full `logging.exception()` traceback at ERROR level. This is noisy in production — especially on WSL where Windows-native agent subprocesses commonly emit `\r\n` blanks.

Strip each line and skip when empty before parsing. Adds a regression test.