### PR TITLE
fix(connection): log unhandled RPC handler exceptions

### DIFF
--- a/src/acp/connection.py
+++ b/src/acp/connection.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import copy
 import inspect
 import json
@@ -272,8 +271,15 @@ class Connection:
 
     async def _run_notification(self, message: dict[str, Any]) -> None:
         method = message["method"]
-        with span_context("acp.notification", attributes={"method": method}), contextlib.suppress(Exception):
-            await self._handler(method, message.get("params"), True)
+        with span_context("acp.notification", attributes={"method": method}):
+            try:
+                await self._handler(method, message.get("params"), True)
+            except Exception as exc:
+                logging.exception(
+                    "Unhandled error while handling notification method=%s",
+                    method,
+                    exc_info=exc,
+                )
 
     async def _handle_response(self, message: dict[str, Any]) -> None:
         request_id = message["id"]

--- a/src/acp/connection.py
+++ b/src/acp/connection.py
@@ -255,6 +255,11 @@ class Connection:
                 self._notify_observers(StreamDirection.OUTGOING, payload)
                 raise err from None
             except Exception as exc:
+                logging.exception(
+                    "Unhandled error while handling request method=%s",
+                    method,
+                    exc_info=exc,
+                )
                 try:
                     data = json.loads(str(exc))
                 except Exception:

--- a/tests/test_request_error_logging.py
+++ b/tests/test_request_error_logging.py
@@ -1,0 +1,46 @@
+import asyncio
+import json
+import logging
+from typing import cast
+
+import pytest
+
+from acp import Agent
+from acp.core import AgentSideConnection
+from tests.conftest import TestAgent
+
+
+@pytest.mark.asyncio
+async def test_unexpected_handler_error_is_logged_and_returns_internal_error(server, caplog):
+    class _RaisingAgent(TestAgent):
+        __test__ = False
+
+        async def initialize(
+            self,
+            protocol_version,
+            client_capabilities=None,
+            client_info=None,
+            **kwargs,
+        ):
+            raise RuntimeError("boom")
+
+    AgentSideConnection(
+        cast(Agent, _RaisingAgent()),
+        server.server_writer,
+        server.server_reader,
+        listening=True,
+    )
+
+    req = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 1}}
+    with caplog.at_level(logging.ERROR):
+        server.client_writer.write((json.dumps(req) + "\n").encode())
+        await server.client_writer.drain()
+        line = await asyncio.wait_for(server.client_reader.readline(), timeout=1)
+
+    resp = json.loads(line)
+    assert resp["id"] == 1
+    assert resp["error"]["code"] == -32603  # internal error
+
+    # The original exception (with its traceback) must be logged, not silently
+    # swallowed into the JSON-RPC response.
+    assert any(record.exc_info for record in caplog.records)

--- a/tests/test_request_error_logging.py
+++ b/tests/test_request_error_logging.py
@@ -44,3 +44,35 @@ async def test_unexpected_handler_error_is_logged_and_returns_internal_error(ser
     # The original exception (with its traceback) must be logged, not silently
     # swallowed into the JSON-RPC response.
     assert any(record.exc_info for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_notification_error_is_logged_and_not_swallowed(server, caplog):
+    class _RaisingCancelAgent(TestAgent):
+        __test__ = False
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.cancel_called = asyncio.Event()
+
+        async def cancel(self, session_id, **kwargs):
+            self.cancel_called.set()
+            raise RuntimeError("boom")
+
+    agent = _RaisingCancelAgent()
+    AgentSideConnection(
+        cast(Agent, agent),
+        server.server_writer,
+        server.server_reader,
+        listening=True,
+    )
+
+    note = {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
+    with caplog.at_level(logging.ERROR):
+        server.client_writer.write((json.dumps(note) + "\n").encode())
+        await server.client_writer.drain()
+        await asyncio.wait_for(agent.cancel_called.wait(), timeout=1)
+
+    # A notification handler that raises must be logged, not silently swallowed,
+    # so integrators can surface it (e.g. to Sentry).
+    assert any(record.exc_info for record in caplog.records)

--- a/tests/test_request_error_logging.py
+++ b/tests/test_request_error_logging.py
@@ -1,78 +1,108 @@
+"""Unhandled RPC handler exceptions must be logged instead of silently swallowed.
+
+Requests already returned a JSON-RPC -32603 error but discarded the original
+traceback; notifications suppressed the exception entirely. Both now log the
+underlying exception so integrators (e.g. Sentry via its logging integration)
+can see server-side handler crashes.
+"""
+
+from __future__ import annotations
+
 import asyncio
-import json
 import logging
-from typing import cast
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
-from acp import Agent
-from acp.core import AgentSideConnection
-from tests.conftest import TestAgent
+from acp.connection import Connection, MethodHandler
+from acp.exceptions import RequestError
+
+
+class _RecordingSender:
+    """Duck-typed MessageSender that records outgoing frames instead of writing them."""
+
+    def __init__(self, writer: asyncio.StreamWriter, supervisor: Any) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+    async def close(self) -> None:
+        pass
+
+
+def _make_connection(handler: MethodHandler) -> tuple[Connection, _RecordingSender]:
+    captured: dict[str, _RecordingSender] = {}
+
+    def sender_factory(writer: asyncio.StreamWriter, supervisor: Any) -> _RecordingSender:
+        captured["sender"] = _RecordingSender(writer, supervisor)
+        return captured["sender"]
+
+    conn = Connection(handler, MagicMock(), MagicMock(), sender_factory=sender_factory, listening=False)
+    return conn, captured["sender"]
+
+
+async def _raising_handler(method: str, params: Any, is_notification: bool) -> Any:
+    raise RuntimeError("kaboom")
+
+
+def _assert_logged_runtime_error(caplog: pytest.LogCaptureFixture, method: str) -> None:
+    records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR and record.exc_info and f"method={method}" in record.getMessage()
+    ]
+    assert len(records) == 1, f"expected exactly one logged error for method={method}"
+    exc_info = records[0].exc_info
+    assert exc_info is not None
+    logged = exc_info[1]
+    assert isinstance(logged, RuntimeError)
+    assert str(logged) == "kaboom"
 
 
 @pytest.mark.asyncio
-async def test_unexpected_handler_error_is_logged_and_returns_internal_error(server, caplog):
-    class _RaisingAgent(TestAgent):
-        __test__ = False
+async def test_run_request_unhandled_exception_is_logged_and_returned_as_internal_error(caplog):
+    conn, sender = _make_connection(_raising_handler)
+    request = {"jsonrpc": "2.0", "id": 7, "method": "explode", "params": None}
 
-        async def initialize(
-            self,
-            protocol_version,
-            client_capabilities=None,
-            client_info=None,
-            **kwargs,
-        ):
-            raise RuntimeError("boom")
+    try:
+        with caplog.at_level(logging.ERROR), pytest.raises(RequestError) as exc_info:
+            await conn._run_request(request)
+    finally:
+        await conn.close()
 
-    AgentSideConnection(
-        cast(Agent, _RaisingAgent()),
-        server.server_writer,
-        server.server_reader,
-        listening=True,
-    )
+    # The handler exception is re-raised as a JSON-RPC internal error...
+    raised = exc_info.value
+    assert isinstance(raised, RequestError)
+    assert raised.code == -32603
+    assert raised.data == {"details": "kaboom"}
 
-    req = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 1}}
-    with caplog.at_level(logging.ERROR):
-        server.client_writer.write((json.dumps(req) + "\n").encode())
-        await server.client_writer.drain()
-        line = await asyncio.wait_for(server.client_reader.readline(), timeout=1)
+    # ...and exactly one error frame carrying the handler's message is written to the peer.
+    assert len(sender.sent) == 1
+    response = sender.sent[0]
+    assert response["id"] == 7
+    assert "result" not in response
+    assert response["error"] == {"code": -32603, "message": "Internal error", "data": {"details": "kaboom"}}
 
-    resp = json.loads(line)
-    assert resp["id"] == 1
-    assert resp["error"]["code"] == -32603  # internal error
-
-    # The original exception (with its traceback) must be logged, not silently
-    # swallowed into the JSON-RPC response.
-    assert any(record.exc_info for record in caplog.records)
+    # The original exception is logged, not discarded by `raise err from None`.
+    _assert_logged_runtime_error(caplog, "explode")
 
 
 @pytest.mark.asyncio
-async def test_unexpected_notification_error_is_logged_and_not_swallowed(server, caplog):
-    class _RaisingCancelAgent(TestAgent):
-        __test__ = False
+async def test_run_notification_unhandled_exception_is_logged_and_not_answered(caplog):
+    conn, sender = _make_connection(_raising_handler)
+    notification = {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
 
-        def __init__(self) -> None:
-            super().__init__()
-            self.cancel_called = asyncio.Event()
+    try:
+        with caplog.at_level(logging.ERROR):
+            result = await conn._run_notification(notification)
+    finally:
+        await conn.close()
 
-        async def cancel(self, session_id, **kwargs):
-            self.cancel_called.set()
-            raise RuntimeError("boom")
+    # A notification has no response: the error is neither raised nor written to the wire.
+    assert result is None
+    assert sender.sent == []
 
-    agent = _RaisingCancelAgent()
-    AgentSideConnection(
-        cast(Agent, agent),
-        server.server_writer,
-        server.server_reader,
-        listening=True,
-    )
-
-    note = {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
-    with caplog.at_level(logging.ERROR):
-        server.client_writer.write((json.dumps(note) + "\n").encode())
-        await server.client_writer.drain()
-        await asyncio.wait_for(agent.cancel_called.wait(), timeout=1)
-
-    # A notification handler that raises must be logged, not silently swallowed,
-    # so integrators can surface it (e.g. to Sentry).
-    assert any(record.exc_info for record in caplog.records)
+    # It must still be logged — previously contextlib.suppress dropped it silently.
+    _assert_logged_runtime_error(caplog, "session/cancel")


### PR DESCRIPTION
## What & why
Server-side handler crashes in `Connection` were converted to a wire error (requests) or silently dropped (notifications) without ever being logged, so integrators wiring an error reporter — e.g. Sentry via its `logging` integration — couldn't see them, forcing them to wrap every handler by hand. This makes both RPC handler paths log unhandled exceptions with their original traceback, consistent with every other error path in the module.

## Changes
1. `_run_request` — log the original exception (with traceback) before converting to JSON-RPC `-32603`; it previously did `raise err from None`, discarding the root-cause traceback.
2. `_run_notification` — replace `contextlib.suppress(Exception)` (swallowed every notification error, no log, no response) with a `try/except` that logs. Drops the now-unused `contextlib` import.

## Tests
`tests/test_request_error_logging.py` — deterministic unit tests drive
`_run_request`/`_run_notification` with a recording sender (asserting the exact wire
frame + that the *original* exception is logged). Verified the suite fails on the pre-fix silent-swallow behaviour.

## Notes for review
- Telemetry unchanged: `suppress` used to exit before `span_context`, so the span never saw the exception; catching inside `try` preserves that.
- No protocol/wire change; no new data exposure.