### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-client-protocol"
-version = "0.11.0"
+version = "0.11.1"
 description = "A Python implement of Agent Client Protocol (ACP, by Zed Industries)"
 authors = [
     { name = "Chojan Shang", email = "psiace@apache.org" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10, <3.15"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
  ## Summary

  Bump the Python SDK version from 0.11.0 to 0.11.1 and sync uv.lock.

  ## Related issues

  None.

  ## Testing

  - make check
  - make test — 125 passed, 2 skipped

  ## Docs & screenshots

  No documentation updates are needed for this patch release.

  ## Checklist

  - [x] Conventional Commit title (chore:).
  - [x] Tests cover the change or are not required.
  - [x] Docs/examples updated when behaviour is user-facing.
  - [x] Schema regeneration is not required; this release continues using schema-v1.16.0.