### PR TITLE
fix(codegen): support datamodel-code-generator 0.71

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Documentation = "https://agentclientprotocol.github.io/python-sdk/"
 
 [dependency-groups]
 dev = [
-    "datamodel-code-generator>=0.25",
+    "datamodel-code-generator>=0.71.0",
     "pytest>=7.2.0",
     "pytest-asyncio>=0.21.0",
     "tox-uv>=1.11.3",

--- a/scripts/gen_schema.py
+++ b/scripts/gen_schema.py
@@ -286,6 +286,7 @@ def generate_schema() -> None:
             "black",
             "isort",
             "--use-annotated",
+            "--use-field-description",
             "--snake-case-field",
         ]
 
@@ -511,6 +512,7 @@ def postprocess_generated_schema(output_path: Path) -> list[str]:
         _ProcessingStep("apply default overrides", _apply_default_overrides),
         _ProcessingStep("restore required nullable fields", _restore_required_nullable_fields),
         _ProcessingStep("ensure custom BaseModel", _ensure_custom_base_model),
+        _ProcessingStep("enable RootModel attribute docstrings", _enable_root_model_attribute_docstrings),
         _ProcessingStep("inject field validators", _inject_field_validators),
         _ProcessingStep("inject deserialize defaults", _inject_deserialize_defaults),
         _ProcessingStep("inject schema aliases", _inject_schema_aliases),
@@ -675,7 +677,7 @@ def _ensure_custom_base_model(content: str) -> str:
         lines[idx] = "from pydantic import " + ", ".join(new_imports)
         to_insert = textwrap.dedent("""\
             class BaseModel(_BaseModel):
-                model_config = ConfigDict(populate_by_name=True)
+                model_config = ConfigDict(populate_by_name=True, use_attribute_docstrings=True)
 
                 def __getattr__(self, item: str) -> Any:
                     if item.lower() != item:
@@ -689,6 +691,24 @@ def _ensure_custom_base_model(content: str) -> str:
             lines.insert(insert_idx + offset, line)
         break
     return "\n".join(lines) + "\n"
+
+
+def _enable_root_model_attribute_docstrings(content: str) -> str:
+    lines = content.splitlines(keepends=True)
+    tree = ast.parse(content)
+    insertion_points = [
+        node.body[0].lineno - 1
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.body
+        and any(
+            isinstance(base, ast.Subscript) and isinstance(base.value, ast.Name) and base.value.id == "RootModel"
+            for base in node.bases
+        )
+    ]
+    for line_index in reversed(insertion_points):
+        lines.insert(line_index, "    model_config = ConfigDict(use_attribute_docstrings=True)\n\n")
+    return "".join(lines)
 
 
 def _ensure_pydantic_import(content: str, name: str) -> str:
@@ -945,8 +965,14 @@ def _restore_required_nullable_fields(content: str, schema: dict[str, Any] | Non
         def restore_block(match: re.Match[str], _field_names: list[str] = field_names) -> str:
             header, block = match.group(1), match.group(2)
             for field_name in _field_names:
-                field_pattern = re.compile(rf"(\n\s+{re.escape(field_name)}:\s+Annotated\[[\s\S]*?\n\s+\]\s*)=\s*None")
-                block = field_pattern.sub(r"\1", block, count=1)
+                field_patterns = (
+                    re.compile(rf"(\n\s+{re.escape(field_name)}:[^\n]*?)\s*=\s*None(?=\n)"),
+                    re.compile(rf"(\n\s+{re.escape(field_name)}:[^\n]*\[\s*\n[\s\S]*?\n\s+\]\s*)=\s*None"),
+                )
+                for field_pattern in field_patterns:
+                    block, count = field_pattern.subn(r"\1", block, count=1)
+                    if count:
+                        break
             return header + block
 
         content = class_pattern.sub(restore_block, content, count=1)
@@ -955,18 +981,14 @@ def _restore_required_nullable_fields(content: str, schema: dict[str, Any] | Non
 
 def _apply_field_overrides(content: str) -> str:
     for class_name, field_name, new_type, optional in FIELD_TYPE_OVERRIDES:
-        if optional:
-            pattern = re.compile(
-                rf"(class {class_name}\(BaseModel\):.*?\n\s+{field_name}:\s+Annotated\[\s*)Optional\[str],",
-                re.DOTALL,
-            )
-            content, count = pattern.subn(rf"\1Optional[{new_type}],", content)
-        else:
-            pattern = re.compile(
-                rf"(class {class_name}\(BaseModel\):.*?\n\s+{field_name}:\s+Annotated\[\s*)str,",
-                re.DOTALL,
-            )
-            content, count = pattern.subn(rf"\1{new_type},", content)
+        old_type = "Optional[str]" if optional else "str"
+        replacement_type = f"Optional[{new_type}]" if optional else new_type
+        pattern = re.compile(
+            rf"(class {re.escape(class_name)}\(BaseModel\):.*?\n\s+{re.escape(field_name)}:\s+"
+            rf"(?:Annotated\[\s*)?){re.escape(old_type)}(?=\s*(?:,|=|\n))",
+            re.DOTALL,
+        )
+        content, count = pattern.subn(rf"\g<1>{replacement_type}", content, count=1)
         if count == 0:
             print(
                 f"Warning: failed to apply type override for {class_name}.{field_name} -> {new_type}",
@@ -992,7 +1014,8 @@ def _apply_default_overrides(content: str) -> str:
             field_patterns: tuple[tuple[re.Pattern[str], Callable[[re.Match[str]], str]], ...] = (
                 (
                     re.compile(
-                        rf"(\n\s+{_field_name}:.*?\]\s*=\s*)([\s\S]*?)(?=\n\s{{4}}[A-Za-z_]|$)",
+                        rf"(\n\s+{_field_name}:.*?\]\s*=\s*)([\s\S]*?)"
+                        rf"(?=\n\s{{4}}(?:[A-Za-z_][A-Za-z0-9_]*\s*:|[rRuUbBfF]*(?:'''|\"\"\"))|$)",
                         re.DOTALL,
                     ),
                     lambda m, _rep=_replacement: m.group(1) + _rep,

--- a/scripts/gen_schema.py
+++ b/scripts/gen_schema.py
@@ -20,13 +20,6 @@ SCHEMA_JSON = SCHEMA_DIR / "schema.json"
 VERSION_FILE = SCHEMA_DIR / "VERSION"
 SCHEMA_OUT = ROOT / "src" / "acp" / "schema.py"
 
-# Pattern caches used when post-processing generated schema.
-FIELD_DECLARATION_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\s*:")
-DESCRIPTION_PATTERN = re.compile(
-    r"description\s*=\s*(?P<prefix>[rRbBuU]*)?(?P<quote>'''|\"\"\"|'|\")(?P<value>.*?)(?P=quote)",
-    re.DOTALL,
-)
-
 STDIO_TYPE_LITERAL = 'Literal["2#-datamodel-code-generator-#-object-#-special-#"]'
 MODELS_TO_REMOVE = [
     "AgentClientProtocol",
@@ -517,7 +510,6 @@ def postprocess_generated_schema(output_path: Path) -> list[str]:
         _ProcessingStep("apply field overrides", _apply_field_overrides),
         _ProcessingStep("apply default overrides", _apply_default_overrides),
         _ProcessingStep("restore required nullable fields", _restore_required_nullable_fields),
-        _ProcessingStep("attach description comments", _add_description_comments),
         _ProcessingStep("ensure custom BaseModel", _ensure_custom_base_model),
         _ProcessingStep("inject field validators", _inject_field_validators),
         _ProcessingStep("inject deserialize defaults", _inject_deserialize_defaults),
@@ -1030,77 +1022,6 @@ def _apply_default_overrides(content: str) -> str:
                 file=sys.stderr,
             )
     return content
-
-
-def _add_description_comments(content: str) -> str:
-    lines = content.splitlines()
-    new_lines: list[str] = []
-    index = 0
-
-    while index < len(lines):
-        line = lines[index]
-        stripped = line.lstrip()
-        indent = len(line) - len(stripped)
-
-        if indent == 4 and FIELD_DECLARATION_PATTERN.match(stripped or ""):
-            block_lines, next_index = _collect_field_block(lines, index, indent)
-            block_text = "\n".join(block_lines)
-            description = _extract_description(block_text)
-
-            if description:
-                indent_str = " " * indent
-                comment_lines = [
-                    f"{indent_str}# {comment_line}" if comment_line else f"{indent_str}#"
-                    for comment_line in description.splitlines()
-                ]
-                if comment_lines:
-                    new_lines.extend(comment_lines)
-
-            new_lines.extend(block_lines)
-            index = next_index
-            continue
-
-        new_lines.append(line)
-        index += 1
-
-    return "\n".join(new_lines)
-
-
-def _collect_field_block(lines: list[str], start: int, indent: int) -> tuple[list[str], int]:
-    block: list[str] = []
-    index = start
-
-    while index < len(lines):
-        current_line = lines[index]
-        current_indent = len(current_line) - len(current_line.lstrip())
-        if index != start and current_line.strip() and current_indent <= indent:
-            break
-
-        block.append(current_line)
-        index += 1
-
-    return block, index
-
-
-def _extract_description(block_text: str) -> str | None:
-    match = DESCRIPTION_PATTERN.search(block_text)
-    if not match:
-        return None
-
-    prefix = match.group("prefix") or ""
-    quote = match.group("quote")
-    value = match.group("value")
-    literal = f"{prefix}{quote}{value}{quote}"
-
-    # datamodel-code-generator emits standard string literals, but fall back to raw text on parse errors.
-    try:
-        parsed = ast.literal_eval(literal)
-    except (SyntaxError, ValueError):
-        return value.replace("\\n", "\n")
-
-    if isinstance(parsed, str):
-        return parsed
-    return str(parsed)
 
 
 def _inject_enum_aliases(content: str) -> str:

--- a/scripts/gen_schema.py
+++ b/scripts/gen_schema.py
@@ -137,6 +137,31 @@ ENUM_LITERAL_MAP: dict[str, tuple[str, ...]] = {
     "ToolKind": ("read", "edit", "delete", "move", "search", "execute", "think", "fetch", "switch_mode", "other"),
 }
 
+# datamodel-code-generator 0.64 promotes referenced string enums to Enum classes.
+# Keep the existing Python API, where these schema types are plain strings; the
+# selected public fields below are narrowed back to the named Literal aliases.
+STRING_ENUM_TYPES = (
+    *ENUM_LITERAL_MAP,
+    "ElicitationSchemaType",
+    "NesDiagnosticSeverity",
+    "NesRejectReason",
+    "NesTriggerKind",
+    "PositionEncodingKind",
+    "Role",
+    "StringFormat",
+    "TextDocumentSyncKind",
+)
+
+# Preserve RootModel classes that existed in the generated public surface before
+# 0.64; other unreferenced RootModels are intermediates left after collapsing.
+PUBLIC_ROOT_MODELS = {
+    "AgentResponse",
+    "ClientResponse",
+    "ElicitationContentValue",
+    "ElicitationFormMode",
+    "ElicitationUrlMode",
+}
+
 FIELD_TYPE_OVERRIDES: tuple[tuple[str, str, str, bool], ...] = (
     ("PermissionOption", "kind", "PermissionOptionKind", False),
     ("PlanEntry", "priority", "PlanEntryPriority", False),
@@ -259,6 +284,14 @@ def generate_schema() -> None:
             "--collapse-root-models",
             "--output-model-type",
             "pydantic_v2.BaseModel",
+            "--no-use-specialized-enum",
+            "--no-use-standard-collections",
+            "--no-use-union-operator",
+            "--type-overrides",
+            json.dumps(dict.fromkeys(STRING_ENUM_TYPES, "builtins.str")),
+            "--formatters",
+            "black",
+            "isort",
             "--use-annotated",
             "--snake-case-field",
         ]
@@ -474,6 +507,9 @@ def postprocess_generated_schema(output_path: Path) -> list[str]:
     header_block = _build_header_block()
 
     content = _strip_existing_header(raw_content)
+    # Type overrides for builtins are rendered as imports in 0.64, but the
+    # annotations should continue to use Python's builtin `str` directly.
+    content = content.replace("from builtins import str\n", "")
     content = _remove_unused_models(content)
     content, leftover_classes = _rename_numbered_models(content)
 
@@ -494,6 +530,7 @@ def postprocess_generated_schema(output_path: Path) -> list[str]:
     missing_targets = _find_missing_targets(content)
 
     content = _inject_enum_aliases(content)
+    content = _remove_unreferenced_root_models(content)
     final_content = header_block + content.rstrip() + "\n"
     if not final_content.endswith("\n"):
         final_content += "\n"
@@ -1078,6 +1115,45 @@ def _inject_enum_aliases(content: str) -> str:
         return content
     insertion_point = class_index + 1  # include leading newline
     return content[:insertion_point] + block + content[insertion_point:]
+
+
+def _remove_unreferenced_root_models(content: str) -> str:
+    tree = ast.parse(content)
+    root_models = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and any(
+            isinstance(base, ast.Subscript) and isinstance(base.value, ast.Name) and base.value.id == "RootModel"
+            for base in node.bases
+        )
+    }
+
+    referenced_roots = set(PUBLIC_ROOT_MODELS)
+    root_dependencies: dict[str, set[str]] = {}
+    for statement in tree.body:
+        loaded_names = {
+            node.id
+            for node in ast.walk(statement)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and node.id in root_models
+        }
+        if isinstance(statement, ast.ClassDef) and statement.name in root_models:
+            root_dependencies[statement.name] = loaded_names
+        else:
+            referenced_roots.update(loaded_names)
+
+    pending = list(referenced_roots)
+    while pending:
+        root_name = pending.pop()
+        for dependency in root_dependencies.get(root_name, set()) - referenced_roots:
+            referenced_roots.add(dependency)
+            pending.append(dependency)
+
+    unused_models = [model for name, model in root_models.items() if name not in referenced_roots]
+    lines = content.splitlines(keepends=True)
+    for model in sorted(unused_models, key=lambda item: item.lineno, reverse=True):
+        del lines[model.lineno - 1 : model.end_lineno]
+    return re.sub(r"\n{4,}", "\n\n\n", "".join(lines))
 
 
 def _remove_unused_models(content: str) -> str:

--- a/scripts/gen_signature.py
+++ b/scripts/gen_signature.py
@@ -127,7 +127,10 @@ class NodeTransformer(ast.NodeTransformer):
         return arg, default
 
     def _format_annotation(self, annotation: t.Any) -> ast.expr:
-        if t.get_origin(annotation) is t.Literal and annotation in self._literals.values():
+        origin = t.get_origin(annotation)
+        if origin is t.Annotated:
+            return self._format_annotation(t.get_args(annotation)[0])
+        if origin is t.Literal and annotation in self._literals.values():
             name = next(name for name, value in self._literals.items() if value is annotation)
             self._add_schema_import(name)
             return ast.Name(id=name)
@@ -139,7 +142,6 @@ class NodeTransformer(ast.NodeTransformer):
             self._add_schema_import(annotation.__name__)
             return ast.Name(id=annotation.__name__)
         elif args := t.get_args(annotation):
-            origin = t.get_origin(annotation)
             return ast.Subscript(
                 value=self._format_annotation(origin),
                 slice=ast.Tuple(elts=[self._format_annotation(arg) for arg in args], ctx=ast.Load())

--- a/src/acp/schema.py
+++ b/src/acp/schema.py
@@ -1311,7 +1311,14 @@ class AuthenticateResponse(BaseModel):
 class ProviderCurrentConfig(BaseModel):
     # Protocol currently used by this provider.
     api_type: Annotated[
-        Union[str, Dict[str, Any]],
+        Union[
+            Literal["anthropic"],
+            Literal["openai"],
+            Literal["azure"],
+            Literal["vertex"],
+            Literal["bedrock"],
+            Dict[str, Any],
+        ],
         Field(alias="apiType", description="Protocol currently used by this provider."),
     ]
     # Base URL currently used by this provider.
@@ -2183,7 +2190,14 @@ class SetProviderRequest(BaseModel):
     provider_id: Annotated[str, Field(alias="providerId", description="Provider ID to configure.")]
     # Protocol type for this provider.
     api_type: Annotated[
-        Union[str, Dict[str, Any]],
+        Union[
+            Literal["anthropic"],
+            Literal["openai"],
+            Literal["azure"],
+            Literal["vertex"],
+            Literal["bedrock"],
+            Dict[str, Any],
+        ],
         Field(alias="apiType", description="Protocol type for this provider."),
     ]
     # Base URL for requests sent through this provider.
@@ -3123,7 +3137,7 @@ class CancelRequestNotification(BaseModel):
             alias="_meta",
             description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
         ),
-    ] = None
+    ]
 
 
 class WriteTextFileRequest(BaseModel):
@@ -3879,7 +3893,16 @@ class ProviderInfo(BaseModel):
     ]
     # Supported protocol types for this provider.
     supported: Annotated[
-        List[Union[str, Dict[str, Any]]],
+        List[
+            Union[
+                Literal["anthropic"],
+                Literal["openai"],
+                Literal["azure"],
+                Literal["vertex"],
+                Literal["bedrock"],
+                Dict[str, Any],
+            ]
+        ],
         Field(description="Supported protocol types for this provider."),
     ]
     # Whether this provider is mandatory and cannot be disabled via `providers/disable`.
@@ -3960,7 +3983,15 @@ class SessionConfigOptionBoolean(SessionConfigBoolean):
     ] = None
     # Optional semantic category for this option (UX only).
     category: Annotated[
-        Optional[Union[str, Dict[str, Any]]],
+        Optional[
+            Union[
+                Literal["mode"],
+                Literal["model"],
+                Literal["model_config"],
+                Literal["thought_level"],
+                Dict[str, Any],
+            ]
+        ],
         Field(description="Optional semantic category for this option (UX only)."),
     ] = None
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -4122,7 +4153,17 @@ class Error(BaseModel):
     # A number indicating the error type that occurred.
     # This must be an integer as defined in the JSON-RPC specification.
     code: Annotated[
-        int,
+        Union[
+            Literal[-32700],
+            Literal[-32600],
+            Literal[-32601],
+            Literal[-32602],
+            Literal[-32603],
+            Literal[-32800],
+            Literal[-32000],
+            Literal[-32002],
+            int,
+        ],
         Field(
             description="A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
         ),
@@ -4674,7 +4715,7 @@ class ClientErrorMessage(BaseModel):
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
-    ] = None
+    ]
     # Method-specific error data.
     error: Annotated[Error, Field(description="Method-specific error data.")]
 
@@ -4867,7 +4908,7 @@ class AgentErrorMessage(BaseModel):
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
-    ] = None
+    ]
     # Method-specific error data.
     error: Annotated[Error, Field(description="Method-specific error data.")]
 
@@ -5243,12 +5284,15 @@ class PromptRequest(BaseModel):
     # pieces of context from sources the agent may not have access to.
     prompt: Annotated[
         List[
-            Union[
-                TextContentBlock,
-                ImageContentBlock,
-                AudioContentBlock,
-                ResourceContentBlock,
-                EmbeddedResourceContentBlock,
+            Annotated[
+                Union[
+                    TextContentBlock,
+                    ImageContentBlock,
+                    AudioContentBlock,
+                    ResourceContentBlock,
+                    EmbeddedResourceContentBlock,
+                ],
+                Field(discriminator="type"),
             ]
         ],
         Field(
@@ -5398,7 +5442,10 @@ class ElicitationSchema(BaseModel):
                 ],
             ]
         ],
-        Field(description="Property definitions (must be primitive types)."),
+        Field(
+            description="Property definitions (must be primitive types).",
+            validate_default=True,
+        ),
     ] = {}
     # List of required property names.
     required: Annotated[Optional[List[str]], Field(description="List of required property names.")] = None
@@ -5504,7 +5551,15 @@ class SessionConfigOptionSelect(SessionConfigSelect):
     ] = None
     # Optional semantic category for this option (UX only).
     category: Annotated[
-        Optional[Union[str, Dict[str, Any]]],
+        Optional[
+            Union[
+                Literal["mode"],
+                Literal["model"],
+                Literal["model_config"],
+                Literal["thought_level"],
+                Dict[str, Any],
+            ]
+        ],
         Field(description="Optional semantic category for this option (UX only)."),
     ] = None
     # The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -5539,7 +5594,14 @@ class LoadSessionResponse(BaseModel):
     ] = None
     # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
-        Optional[List[Union[SessionConfigOptionSelect, SessionConfigOptionBoolean]]],
+        Optional[
+            List[
+                Annotated[
+                    Union[SessionConfigOptionSelect, SessionConfigOptionBoolean],
+                    Field(discriminator="type"),
+                ]
+            ]
+        ],
         Field(
             alias="configOptions",
             description="Initial session configuration options if supported by the Agent.",
@@ -5589,7 +5651,14 @@ class ForkSessionResponse(BaseModel):
     ] = None
     # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
-        Optional[List[Union[SessionConfigOptionSelect, SessionConfigOptionBoolean]]],
+        Optional[
+            List[
+                Annotated[
+                    Union[SessionConfigOptionSelect, SessionConfigOptionBoolean],
+                    Field(discriminator="type"),
+                ]
+            ]
+        ],
         Field(
             alias="configOptions",
             description="Initial session configuration options if supported by the Agent.",
@@ -5631,7 +5700,14 @@ class ResumeSessionResponse(BaseModel):
     ] = None
     # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
-        Optional[List[Union[SessionConfigOptionSelect, SessionConfigOptionBoolean]]],
+        Optional[
+            List[
+                Annotated[
+                    Union[SessionConfigOptionSelect, SessionConfigOptionBoolean],
+                    Field(discriminator="type"),
+                ]
+            ]
+        ],
         Field(
             alias="configOptions",
             description="Initial session configuration options if supported by the Agent.",
@@ -5664,7 +5740,12 @@ class ResumeSessionResponse(BaseModel):
 class SetSessionConfigOptionResponse(BaseModel):
     # The full set of configuration options and their current values.
     config_options: Annotated[
-        List[Union[SessionConfigOptionSelect, SessionConfigOptionBoolean]],
+        List[
+            Annotated[
+                Union[SessionConfigOptionSelect, SessionConfigOptionBoolean],
+                Field(discriminator="type"),
+            ]
+        ],
         Field(
             alias="configOptions",
             description="The full set of configuration options and their current values.",
@@ -5739,7 +5820,14 @@ class ToolCall(BaseModel):
     status: Annotated[Optional[ToolCallStatus], Field(description="Current execution status of the tool call.")] = None
     # Content produced by the tool call.
     content: Annotated[
-        Optional[List[Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent]]],
+        Optional[
+            List[
+                Annotated[
+                    Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent],
+                    Field(discriminator="type"),
+                ]
+            ]
+        ],
         Field(description="Content produced by the tool call."),
     ] = None
     # File locations affected by this tool call.
@@ -5790,7 +5878,12 @@ class ToolCall(BaseModel):
 class _ConfigOptionUpdate(BaseModel):
     # The full set of configuration options and their current values.
     config_options: Annotated[
-        List[Union[SessionConfigOptionSelect, SessionConfigOptionBoolean]],
+        List[
+            Annotated[
+                Union[SessionConfigOptionSelect, SessionConfigOptionBoolean],
+                Field(discriminator="type"),
+            ]
+        ],
         Field(
             alias="configOptions",
             description="The full set of configuration options and their current values.",
@@ -5821,7 +5914,8 @@ class ClientCapabilities(BaseModel):
     fs: Annotated[
         Optional[FileSystemCapabilities],
         Field(
-            description="File system capabilities supported by the client.\nDetermines which file operations the agent can request."
+            description="File system capabilities supported by the client.\nDetermines which file operations the agent can request.",
+            validate_default=True,
         ),
     ] = FileSystemCapabilities()
     # Whether the Client support all `terminal/*` methods.
@@ -5863,7 +5957,8 @@ class ClientCapabilities(BaseModel):
     auth: Annotated[
         Optional[AuthCapabilities],
         Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`."
+            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`.",
+            validate_default=True,
         ),
     ] = {"terminal": False}
     # **UNSTABLE**
@@ -5986,7 +6081,7 @@ class ClientResponseMessage(BaseModel):
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
-    ] = None
+    ]
     # Method-specific response data.
     result: Annotated[
         Union[
@@ -6057,7 +6152,14 @@ class ToolCallUpdate(BaseModel):
     title: Annotated[Optional[str], Field(description="Update the human-readable title.")] = None
     # Replace the content collection.
     content: Annotated[
-        Optional[List[Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent]]],
+        Optional[
+            List[
+                Annotated[
+                    Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent],
+                    Field(discriminator="type"),
+                ]
+            ]
+        ],
         Field(description="Replace the content collection."),
     ] = None
     # Replace the locations collection.
@@ -6235,7 +6337,14 @@ class NewSessionResponse(BaseModel):
     ] = None
     # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
-        Optional[List[Union[SessionConfigOptionSelect, SessionConfigOptionBoolean]]],
+        Optional[
+            List[
+                Annotated[
+                    Union[SessionConfigOptionSelect, SessionConfigOptionBoolean],
+                    Field(discriminator="type"),
+                ]
+            ]
+        ],
         Field(
             alias="configOptions",
             description="Initial session configuration options if supported by the Agent.",
@@ -6269,11 +6378,14 @@ class SuggestNesResponse(BaseModel):
     # The list of suggestions.
     suggestions: Annotated[
         List[
-            Union[
-                NesEditSuggestionVariant,
-                NesJumpSuggestionVariant,
-                NesRenameSuggestionVariant,
-                NesSearchAndReplaceSuggestionVariant,
+            Annotated[
+                Union[
+                    NesEditSuggestionVariant,
+                    NesJumpSuggestionVariant,
+                    NesRenameSuggestionVariant,
+                    NesSearchAndReplaceSuggestionVariant,
+                ],
+                Field(discriminator="kind"),
             ]
         ],
         Field(description="The list of suggestions."),
@@ -6321,6 +6433,7 @@ class InitializeRequest(BaseModel):
         Field(
             alias="clientCapabilities",
             description="Capabilities supported by the client.",
+            validate_default=True,
         ),
     ] = ClientCapabilities()
     # Information about the Client name and version sent to the Agent.
@@ -6424,6 +6537,7 @@ class AgentCapabilities(BaseModel):
         Field(
             alias="promptCapabilities",
             description="Prompt capabilities supported by the agent.",
+            validate_default=True,
         ),
     ] = PromptCapabilities()
     # MCP capabilities supported by the agent.
@@ -6432,6 +6546,7 @@ class AgentCapabilities(BaseModel):
         Field(
             alias="mcpCapabilities",
             description="MCP capabilities supported by the agent.",
+            validate_default=True,
         ),
     ] = McpCapabilities()
     # Session lifecycle and prompt capabilities advertised by the agent.
@@ -6440,12 +6555,16 @@ class AgentCapabilities(BaseModel):
         Field(
             alias="sessionCapabilities",
             description="Session lifecycle and prompt capabilities advertised by the agent.",
+            validate_default=True,
         ),
     ] = SessionCapabilities()
     # Authentication-related capabilities supported by the agent.
     auth: Annotated[
         Optional[AgentAuthCapabilities],
-        Field(description="Authentication-related capabilities supported by the agent."),
+        Field(
+            description="Authentication-related capabilities supported by the agent.",
+            validate_default=True,
+        ),
     ] = {}
     # **UNSTABLE**
     #
@@ -6604,7 +6723,7 @@ class ClientRequest(BaseModel):
             ]
         ],
         Field(description="Method-specific request parameters."),
-    ] = None
+    ]
 
 
 class AgentRequest(BaseModel):
@@ -6641,7 +6760,7 @@ class AgentRequest(BaseModel):
             ]
         ],
         Field(description="Method-specific request parameters."),
-    ] = None
+    ]
 
 
 class InitializeResponse(BaseModel):
@@ -6664,6 +6783,7 @@ class InitializeResponse(BaseModel):
         Field(
             alias="agentCapabilities",
             description="Capabilities supported by the agent.",
+            validate_default=True,
         ),
     ] = AgentCapabilities()
     # Authentication methods supported by the agent.
@@ -6672,6 +6792,7 @@ class InitializeResponse(BaseModel):
         Field(
             alias="authMethods",
             description="Authentication methods supported by the agent.",
+            validate_default=True,
         ),
     ] = []
     # Information about the Agent name and version sent to the Client.
@@ -6745,7 +6866,7 @@ class AgentResponseMessage(BaseModel):
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
-    ] = None
+    ]
     # Method-specific response data.
     result: Annotated[
         Union[

--- a/src/acp/schema.py
+++ b/src/acp/schema.py
@@ -18,7 +18,7 @@ ToolKind = Literal["read", "edit", "delete", "move", "search", "execute", "think
 
 
 class BaseModel(_BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, use_attribute_docstrings=True)
 
     def __getattr__(self, item: str) -> Any:
         if item.lower() != item:
@@ -37,20 +37,30 @@ class Jsonrpc(Enum):
 
 
 class ReadTextFileRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    path: Annotated[str, Field(description="Absolute path to the file to read.")]
-    line: Annotated[
-        Optional[int],
-        Field(description="Line number to start reading from (1-based).", ge=0),
-    ] = None
-    limit: Annotated[Optional[int], Field(description="Maximum number of lines to read.", ge=0)] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    path: str
+    """
+    Absolute path to the file to read.
+    """
+    line: Annotated[Optional[int], Field(ge=0)] = None
+    """
+    Line number to start reading from (1-based).
+    """
+    limit: Annotated[Optional[int], Field(ge=0)] = None
+    """
+    Maximum number of lines to read.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("limit", "line", mode="wrap")
     @classmethod
@@ -59,22 +69,26 @@ class ReadTextFileRequest(BaseModel):
 
 
 class TextResourceContents(BaseModel):
-    mime_type: Annotated[
-        Optional[str],
-        Field(
-            alias="mimeType",
-            description="MIME type describing the encoded media payload.",
-        ),
-    ] = None
-    text: Annotated[str, Field(description="Text payload carried by this content block.")]
-    uri: Annotated[str, Field(description="URI associated with this resource or media payload.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    mime_type: Annotated[Optional[str], Field(alias="mimeType")] = None
+    """
+    MIME type describing the encoded media payload.
+    """
+    text: str
+    """
+    Text payload carried by this content block.
+    """
+    uri: str
+    """
+    URI associated with this resource or media payload.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("mime_type", mode="wrap")
     @classmethod
@@ -83,22 +97,26 @@ class TextResourceContents(BaseModel):
 
 
 class BlobResourceContents(BaseModel):
-    blob: Annotated[str, Field(description="Base64-encoded bytes for a binary resource payload.")]
-    mime_type: Annotated[
-        Optional[str],
-        Field(
-            alias="mimeType",
-            description="MIME type describing the encoded media payload.",
-        ),
-    ] = None
-    uri: Annotated[str, Field(description="URI associated with this resource or media payload.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    blob: str
+    """
+    Base64-encoded bytes for a binary resource payload.
+    """
+    mime_type: Annotated[Optional[str], Field(alias="mimeType")] = None
+    """
+    MIME type describing the encoded media payload.
+    """
+    uri: str
+    """
+    URI associated with this resource or media payload.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("mime_type", mode="wrap")
     @classmethod
@@ -107,19 +125,26 @@ class BlobResourceContents(BaseModel):
 
 
 class Diff(BaseModel):
-    path: Annotated[str, Field(description="The absolute file path being modified.")]
-    old_text: Annotated[
-        Optional[str],
-        Field(alias="oldText", description="The original content (None for new files)."),
-    ] = None
-    new_text: Annotated[str, Field(alias="newText", description="The new content after modification.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    path: str
+    """
+    The absolute file path being modified.
+    """
+    old_text: Annotated[Optional[str], Field(alias="oldText")] = None
+    """
+    The original content (None for new files).
+    """
+    new_text: Annotated[str, Field(alias="newText")]
+    """
+    The new content after modification.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("old_text", mode="wrap")
     @classmethod
@@ -128,32 +153,37 @@ class Diff(BaseModel):
 
 
 class Terminal(BaseModel):
-    terminal_id: Annotated[
-        str,
-        Field(
-            alias="terminalId",
-            description="Identifier of the terminal instance to embed in the content stream.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    terminal_id: Annotated[str, Field(alias="terminalId")]
+    """
+    Identifier of the terminal instance to embed in the content stream.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ToolCallLocation(BaseModel):
-    path: Annotated[str, Field(description="The absolute file path being accessed or modified.")]
-    line: Annotated[Optional[int], Field(description="Optional line number within the file.", ge=0)] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    path: str
+    """
+    The absolute file path being accessed or modified.
+    """
+    line: Annotated[Optional[int], Field(ge=0)] = None
+    """
+    Optional line number within the file.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("line", mode="wrap")
     @classmethod
@@ -162,92 +192,124 @@ class ToolCallLocation(BaseModel):
 
 
 class EnvVariable(BaseModel):
-    name: Annotated[str, Field(description="The name of the environment variable.")]
-    value: Annotated[str, Field(description="The value to set for the environment variable.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    The name of the environment variable.
+    """
+    value: str
+    """
+    The value to set for the environment variable.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class TerminalOutputRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    terminal_id: Annotated[
-        str,
-        Field(alias="terminalId", description="The ID of the terminal to get output from."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    terminal_id: Annotated[str, Field(alias="terminalId")]
+    """
+    The ID of the terminal to get output from.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ReleaseTerminalRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    terminal_id: Annotated[str, Field(alias="terminalId", description="The ID of the terminal to release.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    terminal_id: Annotated[str, Field(alias="terminalId")]
+    """
+    The ID of the terminal to release.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class WaitForTerminalExitRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    terminal_id: Annotated[
-        str,
-        Field(alias="terminalId", description="The ID of the terminal to wait for."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    terminal_id: Annotated[str, Field(alias="terminalId")]
+    """
+    The ID of the terminal to wait for.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class KillTerminalRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    terminal_id: Annotated[str, Field(alias="terminalId", description="The ID of the terminal to kill.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    terminal_id: Annotated[str, Field(alias="terminalId")]
+    """
+    The ID of the terminal to kill.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CreateOtherElicitationRequest(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    message: Annotated[
-        str,
-        Field(description="A human-readable message describing what input is needed."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
-    mode: Annotated[
-        str,
-        Field(
-            description="Custom or future elicitation mode.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants."
-        ),
-    ]
+    message: str
+    """
+    A human-readable message describing what input is needed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
+    mode: str
+    """
+    Custom or future elicitation mode.
+
+    Values beginning with `_` are reserved for implementation-specific
+    extensions. Unknown values that do not begin with `_` are reserved for
+    future ACP variants.
+    """
 
     @field_validator("mode", mode="before")
     @classmethod
@@ -261,14 +323,14 @@ class CreateOtherElicitationRequest(BaseModel):
 
 
 class ElicitationSessionScope(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session this elicitation is tied to."),
-    ]
-    tool_call_id: Annotated[
-        Optional[str],
-        Field(alias="toolCallId", description="Optional tool call within the session."),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session this elicitation is tied to.
+    """
+    tool_call_id: Annotated[Optional[str], Field(alias="toolCallId")] = None
+    """
+    Optional tool call within the session.
+    """
 
     @field_validator("tool_call_id", mode="wrap")
     @classmethod
@@ -277,22 +339,24 @@ class ElicitationSessionScope(BaseModel):
 
 
 class ElicitationRequestScope(BaseModel):
-    request_id: Annotated[
-        Optional[Union[int, str]],
-        Field(alias="requestId", description="The request this elicitation is tied to."),
-    ]
+    request_id: Annotated[Optional[Union[int, str]], Field(alias="requestId")]
+    """
+    The request this elicitation is tied to.
+    """
 
 
 class ElicitationOtherPropertySchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    type: Annotated[
-        str,
-        Field(
-            description="Custom or future elicitation property schema type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants."
-        ),
-    ]
+    type: str
+    """
+    Custom or future elicitation property schema type.
+
+    Values beginning with `_` are reserved for implementation-specific
+    extensions. Unknown values that do not begin with `_` are reserved for
+    future ACP variants.
+    """
 
     @field_validator("type", mode="before")
     @classmethod
@@ -306,16 +370,26 @@ class ElicitationOtherPropertySchema(BaseModel):
 
 
 class EnumOption(BaseModel):
-    const: Annotated[str, Field(description="The constant value for this option.")]
-    title: Annotated[str, Field(description="Human-readable title for this option.")]
-    description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    const: str
+    """
+    The constant value for this option.
+    """
+    title: str
+    """
+    Human-readable title for this option.
+    """
+    description: Optional[str] = None
+    """
+    Human-readable description.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("description", mode="wrap")
     @classmethod
@@ -324,37 +398,50 @@ class EnumOption(BaseModel):
 
 
 class StringPropertySchema(BaseModel):
-    title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    min_length: Annotated[
-        Optional[int],
-        Field(alias="minLength", description="Minimum string length.", ge=0),
-    ] = None
-    max_length: Annotated[
-        Optional[int],
-        Field(alias="maxLength", description="Maximum string length.", ge=0),
-    ] = None
-    pattern: Annotated[Optional[str], Field(description="Pattern the string must match.")] = None
-    format: Annotated[Optional[str], Field(description="String format.")] = None
-    default: Annotated[Optional[str], Field(description="Default value.")] = None
-    enum: Annotated[
-        Optional[List[str]],
-        Field(description="Enum values for untitled single-select enums."),
-    ] = None
-    one_of: Annotated[
-        Optional[List[EnumOption]],
-        Field(
-            alias="oneOf",
-            description="Titled enum options for titled single-select enums.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    title: Optional[str] = None
+    """
+    Optional title for the property.
+    """
+    description: Optional[str] = None
+    """
+    Human-readable description.
+    """
+    min_length: Annotated[Optional[int], Field(alias="minLength", ge=0)] = None
+    """
+    Minimum string length.
+    """
+    max_length: Annotated[Optional[int], Field(alias="maxLength", ge=0)] = None
+    """
+    Maximum string length.
+    """
+    pattern: Optional[str] = None
+    """
+    Pattern the string must match.
+    """
+    format: Optional[str] = None
+    """
+    String format.
+    """
+    default: Optional[str] = None
+    """
+    Default value.
+    """
+    enum: Optional[List[str]] = None
+    """
+    Enum values for untitled single-select enums.
+    """
+    one_of: Annotated[Optional[List[EnumOption]], Field(alias="oneOf")] = None
+    """
+    Titled enum options for titled single-select enums.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("default", "description", "title", mode="wrap")
     @classmethod
@@ -363,18 +450,34 @@ class StringPropertySchema(BaseModel):
 
 
 class NumberPropertySchema(BaseModel):
-    title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    minimum: Annotated[Optional[float], Field(description="Minimum value (inclusive).")] = None
-    maximum: Annotated[Optional[float], Field(description="Maximum value (inclusive).")] = None
-    default: Annotated[Optional[float], Field(description="Default value.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    title: Optional[str] = None
+    """
+    Optional title for the property.
+    """
+    description: Optional[str] = None
+    """
+    Human-readable description.
+    """
+    minimum: Optional[float] = None
+    """
+    Minimum value (inclusive).
+    """
+    maximum: Optional[float] = None
+    """
+    Maximum value (inclusive).
+    """
+    default: Optional[float] = None
+    """
+    Default value.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("default", "description", "title", mode="wrap")
     @classmethod
@@ -383,18 +486,34 @@ class NumberPropertySchema(BaseModel):
 
 
 class IntegerPropertySchema(BaseModel):
-    title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    minimum: Annotated[Optional[int], Field(description="Minimum value (inclusive).")] = None
-    maximum: Annotated[Optional[int], Field(description="Maximum value (inclusive).")] = None
-    default: Annotated[Optional[int], Field(description="Default value.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    title: Optional[str] = None
+    """
+    Optional title for the property.
+    """
+    description: Optional[str] = None
+    """
+    Human-readable description.
+    """
+    minimum: Optional[int] = None
+    """
+    Minimum value (inclusive).
+    """
+    maximum: Optional[int] = None
+    """
+    Maximum value (inclusive).
+    """
+    default: Optional[int] = None
+    """
+    Default value.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("default", "description", "title", mode="wrap")
     @classmethod
@@ -403,16 +522,26 @@ class IntegerPropertySchema(BaseModel):
 
 
 class BooleanPropertySchema(BaseModel):
-    title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    default: Annotated[Optional[bool], Field(description="Default value.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    title: Optional[str] = None
+    """
+    Optional title for the property.
+    """
+    description: Optional[str] = None
+    """
+    Human-readable description.
+    """
+    default: Optional[bool] = None
+    """
+    Default value.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("default", "description", "title", mode="wrap")
     @classmethod
@@ -424,12 +553,14 @@ class OtherMultiSelectItems(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    type: Annotated[
-        str,
-        Field(
-            description="Custom or future multi-select item type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants."
-        ),
-    ]
+    type: str
+    """
+    Custom or future multi-select item type.
+
+    Values beginning with `_` are reserved for implementation-specific
+    extensions. Unknown values that do not begin with `_` are reserved for
+    future ACP variants.
+    """
 
     @field_validator("type", mode="before")
     @classmethod
@@ -443,89 +574,109 @@ class OtherMultiSelectItems(BaseModel):
 
 
 class _StringMultiSelectItems(BaseModel):
-    enum: Annotated[List[str], Field(description="Allowed enum values.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    enum: List[str]
+    """
+    Allowed enum values.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class TitledMultiSelectItems(BaseModel):
-    any_of: Annotated[List[EnumOption], Field(alias="anyOf", description="Titled enum options.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    any_of: Annotated[List[EnumOption], Field(alias="anyOf")]
+    """
+    Titled enum options.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ElicitationUrlSessionMode(ElicitationSessionScope):
-    elicitation_id: Annotated[
-        str,
-        Field(
-            alias="elicitationId",
-            description="The unique identifier for this elicitation.",
-        ),
-    ]
-    url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
+    elicitation_id: Annotated[str, Field(alias="elicitationId")]
+    """
+    The unique identifier for this elicitation.
+    """
+    url: AnyUrl
+    """
+    The URL to direct the user to.
+    """
 
 
 class ElicitationUrlRequestMode(ElicitationRequestScope):
-    elicitation_id: Annotated[
-        str,
-        Field(
-            alias="elicitationId",
-            description="The unique identifier for this elicitation.",
-        ),
-    ]
-    url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
+    elicitation_id: Annotated[str, Field(alias="elicitationId")]
+    """
+    The unique identifier for this elicitation.
+    """
+    url: AnyUrl
+    """
+    The URL to direct the user to.
+    """
 
 
 class ElicitationUrlMode(RootModel[Union[ElicitationUrlSessionMode, ElicitationUrlRequestMode]]):
-    root: Annotated[
-        Union[ElicitationUrlSessionMode, ElicitationUrlRequestMode],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation mode where the client directs the user to a URL."
-        ),
-    ]
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    root: Union[ElicitationUrlSessionMode, ElicitationUrlRequestMode]
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    URL-based elicitation mode where the client directs the user to a URL.
+    """
 
 
 class DisconnectMcpRequest(BaseModel):
-    connection_id: Annotated[
-        str,
-        Field(alias="connectionId", description="The MCP-over-ACP connection to close."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    connection_id: Annotated[str, Field(alias="connectionId")]
+    """
+    The MCP-over-ACP connection to close.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class PromptCapabilities(BaseModel):
-    image: Annotated[Optional[bool], Field(description="Agent supports [`ContentBlock::Image`].")] = False
-    audio: Annotated[Optional[bool], Field(description="Agent supports [`ContentBlock::Audio`].")] = False
-    embedded_context: Annotated[
-        Optional[bool],
-        Field(
-            alias="embeddedContext",
-            description="Agent supports embedded context in `session/prompt` requests.\n\nWhen enabled, the Client is allowed to include [`ContentBlock::Resource`]\nin prompt requests for pieces of context that are referenced in the message.",
-        ),
-    ] = False
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    image: Optional[bool] = False
+    """
+    Agent supports [`ContentBlock::Image`].
+    """
+    audio: Optional[bool] = False
+    """
+    Agent supports [`ContentBlock::Audio`].
+    """
+    embedded_context: Annotated[Optional[bool], Field(alias="embeddedContext")] = False
+    """
+    Agent supports embedded context in `session/prompt` requests.
+
+    When enabled, the Client is allowed to include [`ContentBlock::Resource`]
+    in prompt requests for pieces of context that are referenced in the message.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("audio", "embedded_context", "image", mode="wrap")
     @classmethod
@@ -534,21 +685,30 @@ class PromptCapabilities(BaseModel):
 
 
 class McpCapabilities(BaseModel):
-    http: Annotated[Optional[bool], Field(description="Agent supports [`McpServer::Http`].")] = False
-    sse: Annotated[Optional[bool], Field(description="Agent supports [`McpServer::Sse`].")] = False
-    acp: Annotated[
-        Optional[bool],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAgent supports [`McpServer::Acp`]."
-        ),
-    ] = False
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    http: Optional[bool] = False
+    """
+    Agent supports [`McpServer::Http`].
+    """
+    sse: Optional[bool] = False
+    """
+    Agent supports [`McpServer::Sse`].
+    """
+    acp: Optional[bool] = False
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Agent supports [`McpServer::Acp`].
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("acp", "http", "sse", mode="wrap")
     @classmethod
@@ -557,141 +717,150 @@ class McpCapabilities(BaseModel):
 
 
 class SessionListCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionDeleteCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionAdditionalDirectoriesCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionForkCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionResumeCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionCloseCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class LogoutCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ProvidersCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesDocumentDidOpenCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesDocumentDidCloseCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesDocumentDidSaveCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesDocumentDidFocusCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesRecentFilesCapabilities(BaseModel):
-    max_count: Annotated[
-        Optional[int],
-        Field(
-            alias="maxCount",
-            description="Maximum number of recent files the agent can use.",
-            ge=0,
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    max_count: Annotated[Optional[int], Field(alias="maxCount", ge=0)] = None
+    """
+    Maximum number of recent files the agent can use.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("max_count", mode="wrap")
     @classmethod
@@ -700,31 +869,29 @@ class NesRecentFilesCapabilities(BaseModel):
 
 
 class NesRelatedSnippetsCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesEditHistoryCapabilities(BaseModel):
-    max_count: Annotated[
-        Optional[int],
-        Field(
-            alias="maxCount",
-            description="Maximum number of edit history entries the agent can use.",
-            ge=0,
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    max_count: Annotated[Optional[int], Field(alias="maxCount", ge=0)] = None
+    """
+    Maximum number of edit history entries the agent can use.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("max_count", mode="wrap")
     @classmethod
@@ -733,21 +900,18 @@ class NesEditHistoryCapabilities(BaseModel):
 
 
 class NesUserActionsCapabilities(BaseModel):
-    max_count: Annotated[
-        Optional[int],
-        Field(
-            alias="maxCount",
-            description="Maximum number of user actions the agent can use.",
-            ge=0,
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    max_count: Annotated[Optional[int], Field(alias="maxCount", ge=0)] = None
+    """
+    Maximum number of user actions the agent can use.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("max_count", mode="wrap")
     @classmethod
@@ -756,51 +920,57 @@ class NesUserActionsCapabilities(BaseModel):
 
 
 class NesOpenFilesCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesDiagnosticsCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class AuthEnvVar(BaseModel):
-    name: Annotated[
-        str,
-        Field(description='The environment variable name (e.g. `"OPENAI_API_KEY"`).'),
-    ]
-    label: Annotated[
-        Optional[str],
-        Field(description="Human-readable label for this variable, displayed in client UI."),
-    ] = None
-    secret: Annotated[
-        Optional[bool],
-        Field(
-            description="Whether this value is a secret (e.g. API key, token).\nClients should use a password-style input for secret vars.\n\nDefaults to `true`."
-        ),
-    ] = True
-    optional: Annotated[
-        Optional[bool],
-        Field(description="Whether this variable is optional.\n\nDefaults to `false`."),
-    ] = False
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    The environment variable name (e.g. `"OPENAI_API_KEY"`).
+    """
+    label: Optional[str] = None
+    """
+    Human-readable label for this variable, displayed in client UI.
+    """
+    secret: Optional[bool] = True
+    """
+    Whether this value is a secret (e.g. API key, token).
+    Clients should use a password-style input for secret vars.
+
+    Defaults to `true`.
+    """
+    optional: Optional[bool] = False
+    """
+    Whether this variable is optional.
+
+    Defaults to `false`.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("optional", mode="wrap")
     @classmethod
@@ -819,27 +989,34 @@ class AuthEnvVar(BaseModel):
 
 
 class AuthMethodEnvVar(BaseModel):
-    id: Annotated[str, Field(description="Unique identifier for this authentication method.")]
-    name: Annotated[str, Field(description="Human-readable name of the authentication method.")]
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional description providing more details about this authentication method."),
-    ] = None
-    vars: Annotated[
-        List[AuthEnvVar],
-        Field(description="The environment variables the client should set."),
-    ]
-    link: Annotated[
-        Optional[str],
-        Field(description="Optional link to a page where the user can obtain their credentials."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Unique identifier for this authentication method.
+    """
+    name: str
+    """
+    Human-readable name of the authentication method.
+    """
+    description: Optional[str] = None
+    """
+    Optional description providing more details about this authentication method.
+    """
+    vars: List[AuthEnvVar]
+    """
+    The environment variables the client should set.
+    """
+    link: Optional[str] = None
+    """
+    Optional link to a page where the user can obtain their credentials.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("description", "link", mode="wrap")
     @classmethod
@@ -853,27 +1030,34 @@ class AuthMethodEnvVar(BaseModel):
 
 
 class AuthMethodTerminal(BaseModel):
-    id: Annotated[str, Field(description="Unique identifier for this authentication method.")]
-    name: Annotated[str, Field(description="Human-readable name of the authentication method.")]
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional description providing more details about this authentication method."),
-    ] = None
-    args: Annotated[
-        Optional[List[str]],
-        Field(description="Additional arguments to pass when running the agent binary for terminal auth."),
-    ] = None
-    env: Annotated[
-        Optional[Dict[str, str]],
-        Field(description="Additional environment variables to set when running the agent binary for terminal auth."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Unique identifier for this authentication method.
+    """
+    name: str
+    """
+    Human-readable name of the authentication method.
+    """
+    description: Optional[str] = None
+    """
+    Optional description providing more details about this authentication method.
+    """
+    args: Optional[List[str]] = None
+    """
+    Additional arguments to pass when running the agent binary for terminal auth.
+    """
+    env: Optional[Dict[str, str]] = None
+    """
+    Additional environment variables to set when running the agent binary for terminal auth.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("description", "env", mode="wrap")
     @classmethod
@@ -887,19 +1071,26 @@ class AuthMethodTerminal(BaseModel):
 
 
 class AuthMethodAgent(BaseModel):
-    id: Annotated[str, Field(description="Unique identifier for this authentication method.")]
-    name: Annotated[str, Field(description="Human-readable name of the authentication method.")]
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional description providing more details about this authentication method."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Unique identifier for this authentication method.
+    """
+    name: str
+    """
+    Human-readable name of the authentication method.
+    """
+    description: Optional[str] = None
+    """
+    Optional description providing more details about this authentication method.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("description", mode="wrap")
     @classmethod
@@ -908,31 +1099,31 @@ class AuthMethodAgent(BaseModel):
 
 
 class Implementation(BaseModel):
-    name: Annotated[
-        str,
-        Field(
-            description="Intended for programmatic or logical use, but can be used as a display\nname fallback if title isn’t present."
-        ),
-    ]
-    title: Annotated[
-        Optional[str],
-        Field(
-            description="Intended for UI and end-user contexts — optimized to be human-readable\nand easily understood.\n\nIf not provided, the name should be used for display."
-        ),
-    ] = None
-    version: Annotated[
-        str,
-        Field(
-            description='Version of the implementation. Can be displayed to the user or used\nfor debugging or metrics purposes. (e.g. "1.0.0").'
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    Intended for programmatic or logical use, but can be used as a display
+    name fallback if title isn’t present.
+    """
+    title: Optional[str] = None
+    """
+    Intended for UI and end-user contexts — optimized to be human-readable
+    and easily understood.
+
+    If not provided, the name should be used for display.
+    """
+    version: str
+    """
+    Version of the implementation. Can be displayed to the user or used
+    for debugging or metrics purposes. (e.g. "1.0.0").
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("title", mode="wrap")
     @classmethod
@@ -941,13 +1132,14 @@ class Implementation(BaseModel):
 
 
 class AuthenticateResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ProviderCurrentConfig(BaseModel):
@@ -960,68 +1152,79 @@ class ProviderCurrentConfig(BaseModel):
             Literal["bedrock"],
             Dict[str, Any],
         ],
-        Field(alias="apiType", description="Protocol currently used by this provider."),
+        Field(alias="apiType"),
     ]
-    base_url: Annotated[
-        str,
-        Field(alias="baseUrl", description="Base URL currently used by this provider."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Protocol currently used by this provider.
+    """
+    base_url: Annotated[str, Field(alias="baseUrl")]
+    """
+    Base URL currently used by this provider.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SetProviderResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DisableProviderResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class LogoutResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionMode(BaseModel):
-    id: Annotated[
-        str,
-        Field(description="Stable identifier used to refer to this protocol object in later messages."),
-    ]
-    name: Annotated[str, Field(description="Human-readable name shown for this protocol object.")]
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional human-readable details shown with this protocol object."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Stable identifier used to refer to this protocol object in later messages.
+    """
+    name: str
+    """
+    Human-readable name shown for this protocol object.
+    """
+    description: Optional[str] = None
+    """
+    Optional human-readable details shown with this protocol object.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("description", mode="wrap")
     @classmethod
@@ -1030,16 +1233,26 @@ class SessionMode(BaseModel):
 
 
 class SessionConfigSelectOption(BaseModel):
-    value: Annotated[str, Field(description="Unique identifier for this option value.")]
-    name: Annotated[str, Field(description="Human-readable label for this option value.")]
-    description: Annotated[Optional[str], Field(description="Optional description for this option value.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    value: str
+    """
+    Unique identifier for this option value.
+    """
+    name: str
+    """
+    Human-readable label for this option value.
+    """
+    description: Optional[str] = None
+    """
+    Optional description for this option value.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("description", mode="wrap")
     @classmethod
@@ -1048,37 +1261,45 @@ class SessionConfigSelectOption(BaseModel):
 
 
 class SessionConfigBoolean(BaseModel):
-    current_value: Annotated[
-        bool,
-        Field(alias="currentValue", description="The current value of the boolean option."),
-    ]
+    current_value: Annotated[bool, Field(alias="currentValue")]
+    """
+    The current value of the boolean option.
+    """
 
 
 class SessionInfo(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="Unique identifier for the session")]
-    cwd: Annotated[
-        str,
-        Field(description="The working directory for this session. Must be an absolute path."),
-    ]
-    additional_directories: Annotated[
-        Optional[List[str]],
-        Field(
-            alias="additionalDirectories",
-            description="Additional workspace roots reported for this session. Each path must be absolute.\n\nWhen present, this is the complete ordered additional-root list reported\nby the Agent. Omitted and empty values are equivalent: the response\nreports no additional roots.",
-        ),
-    ] = None
-    title: Annotated[Optional[str], Field(description="Human-readable title for the session")] = None
-    updated_at: Annotated[
-        Optional[str],
-        Field(alias="updatedAt", description="ISO 8601 timestamp of last activity"),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    Unique identifier for the session
+    """
+    cwd: str
+    """
+    The working directory for this session. Must be an absolute path.
+    """
+    additional_directories: Annotated[Optional[List[str]], Field(alias="additionalDirectories")] = None
+    """
+    Additional workspace roots reported for this session. Each path must be absolute.
+
+    When present, this is the complete ordered additional-root list reported
+    by the Agent. Omitted and empty values are equivalent: the response
+    reports no additional roots.
+    """
+    title: Optional[str] = None
+    """
+    Human-readable title for the session
+    """
+    updated_at: Annotated[Optional[str], Field(alias="updatedAt")] = None
+    """
+    ISO 8601 timestamp of last activity
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("title", "updated_at", mode="wrap")
     @classmethod
@@ -1092,79 +1313,71 @@ class SessionInfo(BaseModel):
 
 
 class DeleteSessionResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CloseSessionResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SetSessionModeResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class Usage(BaseModel):
-    total_tokens: Annotated[
-        int,
-        Field(
-            alias="totalTokens",
-            description="Sum of all token types across session.",
-            ge=0,
-        ),
-    ]
-    input_tokens: Annotated[
-        int,
-        Field(
-            alias="inputTokens",
-            description="Total input tokens across all turns.",
-            ge=0,
-        ),
-    ]
-    output_tokens: Annotated[
-        int,
-        Field(
-            alias="outputTokens",
-            description="Total output tokens across all turns.",
-            ge=0,
-        ),
-    ]
-    thought_tokens: Annotated[
-        Optional[int],
-        Field(alias="thoughtTokens", description="Total thought/reasoning tokens", ge=0),
-    ] = None
-    cached_read_tokens: Annotated[
-        Optional[int],
-        Field(alias="cachedReadTokens", description="Total cache read tokens.", ge=0),
-    ] = None
-    cached_write_tokens: Annotated[
-        Optional[int],
-        Field(alias="cachedWriteTokens", description="Total cache write tokens.", ge=0),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    total_tokens: Annotated[int, Field(alias="totalTokens", ge=0)]
+    """
+    Sum of all token types across session.
+    """
+    input_tokens: Annotated[int, Field(alias="inputTokens", ge=0)]
+    """
+    Total input tokens across all turns.
+    """
+    output_tokens: Annotated[int, Field(alias="outputTokens", ge=0)]
+    """
+    Total output tokens across all turns.
+    """
+    thought_tokens: Annotated[Optional[int], Field(alias="thoughtTokens", ge=0)] = None
+    """
+    Total thought/reasoning tokens
+    """
+    cached_read_tokens: Annotated[Optional[int], Field(alias="cachedReadTokens", ge=0)] = None
+    """
+    Total cache read tokens.
+    """
+    cached_write_tokens: Annotated[Optional[int], Field(alias="cachedWriteTokens", ge=0)] = None
+    """
+    Total cache write tokens.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("cached_read_tokens", "cached_write_tokens", "thought_tokens", mode="wrap")
     @classmethod
@@ -1173,174 +1386,231 @@ class Usage(BaseModel):
 
 
 class StartNesResponse(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="The session ID for the newly started NES session.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for the newly started NES session.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class Position(BaseModel):
-    line: Annotated[int, Field(description="Zero-based line number.", ge=0)]
-    character: Annotated[
-        int,
-        Field(description="Zero-based character offset (encoding-dependent).", ge=0),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    line: Annotated[int, Field(ge=0)]
+    """
+    Zero-based line number.
+    """
+    character: Annotated[int, Field(ge=0)]
+    """
+    Zero-based character offset (encoding-dependent).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesJumpSuggestion(BaseModel):
-    id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    uri: Annotated[str, Field(description="The file to navigate to.")]
-    position: Annotated[Position, Field(description="The target position within the file.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Unique identifier for accept/reject tracking.
+    """
+    uri: str
+    """
+    The file to navigate to.
+    """
+    position: Position
+    """
+    The target position within the file.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesRenameSuggestion(BaseModel):
-    id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    uri: Annotated[str, Field(description="The file URI containing the symbol.")]
-    position: Annotated[Position, Field(description="The position of the symbol to rename.")]
-    new_name: Annotated[str, Field(alias="newName", description="The new name for the symbol.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Unique identifier for accept/reject tracking.
+    """
+    uri: str
+    """
+    The file URI containing the symbol.
+    """
+    position: Position
+    """
+    The position of the symbol to rename.
+    """
+    new_name: Annotated[str, Field(alias="newName")]
+    """
+    The new name for the symbol.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesSearchAndReplaceSuggestion(BaseModel):
-    id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    uri: Annotated[str, Field(description="The file URI to search within.")]
-    search: Annotated[str, Field(description="The text or pattern to find.")]
-    replace: Annotated[str, Field(description="The replacement text.")]
-    is_regex: Annotated[
-        Optional[bool],
-        Field(
-            alias="isRegex",
-            description="Whether `search` is a regular expression. Defaults to `false`.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Unique identifier for accept/reject tracking.
+    """
+    uri: str
+    """
+    The file URI to search within.
+    """
+    search: str
+    """
+    The text or pattern to find.
+    """
+    replace: str
+    """
+    The replacement text.
+    """
+    is_regex: Annotated[Optional[bool], Field(alias="isRegex")] = None
+    """
+    Whether `search` is a regular expression. Defaults to `false`.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CloseNesResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class PlanFile(BaseModel):
-    plan_id: Annotated[str, Field(alias="planId", description="The plan ID to update.")]
-    uri: Annotated[str, Field(description="The URI of the file containing the plan.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    plan_id: Annotated[str, Field(alias="planId")]
+    """
+    The plan ID to update.
+    """
+    uri: str
+    """
+    The URI of the file containing the plan.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class PlanMarkdown(BaseModel):
-    plan_id: Annotated[str, Field(alias="planId", description="The plan ID to update.")]
-    content: Annotated[str, Field(description="Markdown content for the plan.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    plan_id: Annotated[str, Field(alias="planId")]
+    """
+    The plan ID to update.
+    """
+    content: str
+    """
+    Markdown content for the plan.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class PlanRemoved(BaseModel):
-    plan_id: Annotated[str, Field(alias="planId", description="The plan ID to remove.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    plan_id: Annotated[str, Field(alias="planId")]
+    """
+    The plan ID to remove.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class UnstructuredCommandInput(BaseModel):
-    hint: Annotated[
-        str,
-        Field(description="A hint to display when the input hasn't been provided yet"),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    hint: str
+    """
+    A hint to display when the input hasn't been provided yet
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class _CurrentModeUpdate(BaseModel):
-    current_mode_id: Annotated[str, Field(alias="currentModeId", description="The ID of the current mode")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    current_mode_id: Annotated[str, Field(alias="currentModeId")]
+    """
+    The ID of the current mode
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class _SessionInfoUpdate(BaseModel):
-    title: Annotated[
-        Optional[str],
-        Field(description="Human-readable title for the session. Set to null to clear."),
-    ] = None
-    updated_at: Annotated[
-        Optional[str],
-        Field(
-            alias="updatedAt",
-            description="ISO 8601 timestamp of last activity. Set to null to clear.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    title: Optional[str] = None
+    """
+    Human-readable title for the session. Set to null to clear.
+    """
+    updated_at: Annotated[Optional[str], Field(alias="updatedAt")] = None
+    """
+    ISO 8601 timestamp of last activity. Set to null to clear.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("title", "updated_at", mode="wrap")
     @classmethod
@@ -1349,28 +1619,45 @@ class _SessionInfoUpdate(BaseModel):
 
 
 class Cost(BaseModel):
-    amount: Annotated[float, Field(description="Total cumulative cost for session.")]
-    currency: Annotated[str, Field(description='ISO 4217 currency code (e.g., "USD", "EUR").')]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    amount: float
+    """
+    Total cumulative cost for session.
+    """
+    currency: str
+    """
+    ISO 4217 currency code (e.g., "USD", "EUR").
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class _UsageUpdate(BaseModel):
-    used: Annotated[int, Field(description="Tokens currently in context.", ge=0)]
-    size: Annotated[int, Field(description="Total context window size in tokens.", ge=0)]
-    cost: Annotated[Optional[Cost], Field(description="Cumulative session cost (optional).")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    used: Annotated[int, Field(ge=0)]
+    """
+    Tokens currently in context.
+    """
+    size: Annotated[int, Field(ge=0)]
+    """
+    Total context window size in tokens.
+    """
+    cost: Optional[Cost] = None
+    """
+    Cumulative session cost (optional).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("cost", mode="wrap")
     @classmethod
@@ -1379,44 +1666,43 @@ class _UsageUpdate(BaseModel):
 
 
 class CompleteElicitationNotification(BaseModel):
-    elicitation_id: Annotated[
-        str,
-        Field(
-            alias="elicitationId",
-            description="The ID of the elicitation that completed.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    elicitation_id: Annotated[str, Field(alias="elicitationId")]
+    """
+    The ID of the elicitation that completed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class MessageMcpNotification(BaseModel):
-    connection_id: Annotated[
-        str,
-        Field(
-            alias="connectionId",
-            description="The MCP-over-ACP connection this message is sent on.",
-        ),
-    ]
-    method: Annotated[str, Field(description="The inner MCP method name.")]
-    params: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            description="Optional inner MCP params.\n\nIf omitted or set to `null`, the inner MCP message has no params."
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    connection_id: Annotated[str, Field(alias="connectionId")]
+    """
+    The MCP-over-ACP connection this message is sent on.
+    """
+    method: str
+    """
+    The inner MCP method name.
+    """
+    params: Optional[Dict[str, Any]] = None
+    """
+    Optional inner MCP params.
+
+    If omitted or set to `null`, the inner MCP message has no params.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("params", mode="wrap")
     @classmethod
@@ -1425,27 +1711,22 @@ class MessageMcpNotification(BaseModel):
 
 
 class FileSystemCapabilities(BaseModel):
-    read_text_file: Annotated[
-        Optional[bool],
-        Field(
-            alias="readTextFile",
-            description="Whether the Client supports `fs/read_text_file` requests.",
-        ),
-    ] = False
-    write_text_file: Annotated[
-        Optional[bool],
-        Field(
-            alias="writeTextFile",
-            description="Whether the Client supports `fs/write_text_file` requests.",
-        ),
-    ] = False
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    read_text_file: Annotated[Optional[bool], Field(alias="readTextFile")] = False
+    """
+    Whether the Client supports `fs/read_text_file` requests.
+    """
+    write_text_file: Annotated[Optional[bool], Field(alias="writeTextFile")] = False
+    """
+    Whether the Client supports `fs/write_text_file` requests.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("read_text_file", "write_text_file", mode="wrap")
     @classmethod
@@ -1454,39 +1735,42 @@ class FileSystemCapabilities(BaseModel):
 
 
 class BooleanConfigOptionCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class PlanCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class AuthCapabilities(BaseModel):
-    terminal: Annotated[
-        Optional[bool],
-        Field(
-            description="Whether the client supports `terminal` authentication methods.\n\nWhen `true`, the agent may include `terminal` entries in its authentication methods."
-        ),
-    ] = False
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    terminal: Optional[bool] = False
+    """
+    Whether the client supports `terminal` authentication methods.
+
+    When `true`, the agent may include `terminal` entries in its authentication methods.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("terminal", mode="wrap")
     @classmethod
@@ -1495,84 +1779,92 @@ class AuthCapabilities(BaseModel):
 
 
 class ElicitationFormCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ElicitationUrlCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesJumpCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesRenameCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesSearchAndReplaceCapabilities(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class AuthenticateRequest(BaseModel):
-    method_id: Annotated[
-        str,
-        Field(
-            alias="methodId",
-            description="The ID of the authentication method to use.\nMust be one of the methods advertised in the initialize response.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    method_id: Annotated[str, Field(alias="methodId")]
+    """
+    The ID of the authentication method to use.
+    Must be one of the methods advertised in the initialize response.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ListProvidersRequest(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SetProviderRequest(BaseModel):
-    provider_id: Annotated[str, Field(alias="providerId", description="Provider ID to configure.")]
+    provider_id: Annotated[str, Field(alias="providerId")]
+    """
+    Provider ID to configure.
+    """
     api_type: Annotated[
         Union[
             Literal["anthropic"],
@@ -1582,366 +1874,458 @@ class SetProviderRequest(BaseModel):
             Literal["bedrock"],
             Dict[str, Any],
         ],
-        Field(alias="apiType", description="Protocol type for this provider."),
+        Field(alias="apiType"),
     ]
-    base_url: Annotated[
-        str,
-        Field(
-            alias="baseUrl",
-            description="Base URL for requests sent through this provider.",
-        ),
-    ]
-    headers: Annotated[
-        Optional[Dict[str, str]],
-        Field(
-            description="Full headers map for this provider.\nMay include authorization, routing, or other integration-specific headers."
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Protocol type for this provider.
+    """
+    base_url: Annotated[str, Field(alias="baseUrl")]
+    """
+    Base URL for requests sent through this provider.
+    """
+    headers: Optional[Dict[str, str]] = None
+    """
+    Full headers map for this provider.
+    May include authorization, routing, or other integration-specific headers.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DisableProviderRequest(BaseModel):
-    provider_id: Annotated[str, Field(alias="providerId", description="Provider ID to disable.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    provider_id: Annotated[str, Field(alias="providerId")]
+    """
+    Provider ID to disable.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class LogoutRequest(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class HttpHeader(BaseModel):
-    name: Annotated[str, Field(description="The name of the HTTP header.")]
-    value: Annotated[str, Field(description="The value to set for the HTTP header.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    The name of the HTTP header.
+    """
+    value: str
+    """
+    The value to set for the HTTP header.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class McpServerHttp(BaseModel):
-    name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    url: Annotated[str, Field(description="URL to the MCP server.")]
-    headers: Annotated[
-        List[HttpHeader],
-        Field(description="HTTP headers to set when making requests to the MCP server."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    Human-readable name identifying this MCP server.
+    """
+    url: str
+    """
+    URL to the MCP server.
+    """
+    headers: List[HttpHeader]
+    """
+    HTTP headers to set when making requests to the MCP server.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class McpServerSse(BaseModel):
-    name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    url: Annotated[str, Field(description="URL to the MCP server.")]
-    headers: Annotated[
-        List[HttpHeader],
-        Field(description="HTTP headers to set when making requests to the MCP server."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    Human-readable name identifying this MCP server.
+    """
+    url: str
+    """
+    URL to the MCP server.
+    """
+    headers: List[HttpHeader]
+    """
+    HTTP headers to set when making requests to the MCP server.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class McpServerAcp(BaseModel):
-    name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    server_id: Annotated[
-        str,
-        Field(
-            alias="serverId",
-            description="Unique identifier for this MCP server, generated by the component providing it.\n\nProviders MUST NOT reuse an ID for multiple ACP-transport MCP servers that are visible\non the same ACP connection.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    Human-readable name identifying this MCP server.
+    """
+    server_id: Annotated[str, Field(alias="serverId")]
+    """
+    Unique identifier for this MCP server, generated by the component providing it.
+
+    Providers MUST NOT reuse an ID for multiple ACP-transport MCP servers that are visible
+    on the same ACP connection.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class McpServerStdio(BaseModel):
-    name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    command: Annotated[str, Field(description="Absolute path to the MCP server executable.")]
-    args: Annotated[
-        List[str],
-        Field(description="Command-line arguments to pass to the MCP server."),
-    ]
-    env: Annotated[
-        List[EnvVariable],
-        Field(description="Environment variables to set when launching the MCP server."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    Human-readable name identifying this MCP server.
+    """
+    command: str
+    """
+    Absolute path to the MCP server executable.
+    """
+    args: List[str]
+    """
+    Command-line arguments to pass to the MCP server.
+    """
+    env: List[EnvVariable]
+    """
+    Environment variables to set when launching the MCP server.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ListSessionsRequest(BaseModel):
-    cwd: Annotated[
-        Optional[str],
-        Field(description="Filter sessions by working directory. Must be an absolute path."),
-    ] = None
-    cursor: Annotated[
-        Optional[str],
-        Field(
-            description="Opaque cursor token from a previous response's nextCursor field for cursor-based pagination"
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    cwd: Optional[str] = None
+    """
+    Filter sessions by working directory. Must be an absolute path.
+    """
+    cursor: Optional[str] = None
+    """
+    Opaque cursor token from a previous response's nextCursor field for cursor-based pagination
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DeleteSessionRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to delete.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to delete.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CloseSessionRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to close.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to close.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SetSessionModeRequest(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The ID of the session to set the mode for."),
-    ]
-    mode_id: Annotated[str, Field(alias="modeId", description="The ID of the mode to set.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to set the mode for.
+    """
+    mode_id: Annotated[str, Field(alias="modeId")]
+    """
+    The ID of the mode to set.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SetSessionConfigOptionBooleanRequest(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="The ID of the session to set the configuration option for.",
-        ),
-    ]
-    config_id: Annotated[
-        str,
-        Field(alias="configId", description="The ID of the configuration option to set."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
-    value: Annotated[bool, Field(description="The boolean value.")]
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to set the configuration option for.
+    """
+    config_id: Annotated[str, Field(alias="configId")]
+    """
+    The ID of the configuration option to set.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
+    value: bool
+    """
+    The boolean value.
+    """
     type: Literal["boolean"]
 
 
 class SetSessionConfigOptionSelectRequest(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="The ID of the session to set the configuration option for.",
-        ),
-    ]
-    config_id: Annotated[
-        str,
-        Field(alias="configId", description="The ID of the configuration option to set."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
-    value: Annotated[str, Field(description="The value ID.")]
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to set the configuration option for.
+    """
+    config_id: Annotated[str, Field(alias="configId")]
+    """
+    The ID of the configuration option to set.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
+    value: str
+    """
+    The value ID.
+    """
 
 
 class WorkspaceFolder(BaseModel):
-    uri: Annotated[str, Field(description="The URI of the folder.")]
-    name: Annotated[str, Field(description="The display name of the folder.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    uri: str
+    """
+    The URI of the folder.
+    """
+    name: str
+    """
+    The display name of the folder.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesRepository(BaseModel):
-    name: Annotated[str, Field(description="The repository name.")]
-    owner: Annotated[str, Field(description="The repository owner.")]
-    remote_url: Annotated[str, Field(alias="remoteUrl", description="The remote URL of the repository.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    The repository name.
+    """
+    owner: str
+    """
+    The repository owner.
+    """
+    remote_url: Annotated[str, Field(alias="remoteUrl")]
+    """
+    The remote URL of the repository.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesRecentFile(BaseModel):
-    uri: Annotated[str, Field(description="The URI of the file.")]
-    language_id: Annotated[str, Field(alias="languageId", description="The language identifier.")]
-    text: Annotated[str, Field(description="The full text content of the file.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    uri: str
+    """
+    The URI of the file.
+    """
+    language_id: Annotated[str, Field(alias="languageId")]
+    """
+    The language identifier.
+    """
+    text: str
+    """
+    The full text content of the file.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesExcerpt(BaseModel):
-    start_line: Annotated[
-        int,
-        Field(
-            alias="startLine",
-            description="The start line of the excerpt (zero-based).",
-            ge=0,
-        ),
-    ]
-    end_line: Annotated[
-        int,
-        Field(
-            alias="endLine",
-            description="The end line of the excerpt (zero-based).",
-            ge=0,
-        ),
-    ]
-    text: Annotated[str, Field(description="The text content of the excerpt.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    start_line: Annotated[int, Field(alias="startLine", ge=0)]
+    """
+    The start line of the excerpt (zero-based).
+    """
+    end_line: Annotated[int, Field(alias="endLine", ge=0)]
+    """
+    The end line of the excerpt (zero-based).
+    """
+    text: str
+    """
+    The text content of the excerpt.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesEditHistoryEntry(BaseModel):
-    uri: Annotated[str, Field(description="The URI of the edited file.")]
-    diff: Annotated[str, Field(description="A diff representing the edit.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    uri: str
+    """
+    The URI of the edited file.
+    """
+    diff: str
+    """
+    A diff representing the edit.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesUserAction(BaseModel):
-    action: Annotated[
-        str,
-        Field(description='The kind of action (e.g., "insertChar", "cursorMovement").'),
-    ]
-    uri: Annotated[str, Field(description="The URI of the file where the action occurred.")]
-    position: Annotated[Position, Field(description="The position where the action occurred.")]
-    timestamp_ms: Annotated[
-        int,
-        Field(
-            alias="timestampMs",
-            description="Timestamp in milliseconds since epoch.",
-            ge=0,
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    action: str
+    """
+    The kind of action (e.g., "insertChar", "cursorMovement").
+    """
+    uri: str
+    """
+    The URI of the file where the action occurred.
+    """
+    position: Position
+    """
+    The position where the action occurred.
+    """
+    timestamp_ms: Annotated[int, Field(alias="timestampMs", ge=0)]
+    """
+    Timestamp in milliseconds since epoch.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CloseNesRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the NES session to close.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the NES session to close.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class WriteTextFileResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ReadTextFileResponse(BaseModel):
-    content: Annotated[str, Field(description="Content payload returned by this response.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    content: str
+    """
+    Content payload returned by this response.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DeniedOutcome(BaseModel):
@@ -1949,56 +2333,52 @@ class DeniedOutcome(BaseModel):
 
 
 class SelectedPermissionOutcome(BaseModel):
-    option_id: Annotated[
-        str,
-        Field(alias="optionId", description="The ID of the option the user selected."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    option_id: Annotated[str, Field(alias="optionId")]
+    """
+    The ID of the option the user selected.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CreateTerminalResponse(BaseModel):
-    terminal_id: Annotated[
-        str,
-        Field(
-            alias="terminalId",
-            description="The unique identifier for the created terminal.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    terminal_id: Annotated[str, Field(alias="terminalId")]
+    """
+    The unique identifier for the created terminal.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class TerminalExitStatus(BaseModel):
-    exit_code: Annotated[
-        Optional[int],
-        Field(
-            alias="exitCode",
-            description="The process exit code (may be null if terminated by signal).",
-            ge=0,
-        ),
-    ] = None
-    signal: Annotated[
-        Optional[str],
-        Field(description="The signal that terminated the process (may be null if exited normally)."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    exit_code: Annotated[Optional[int], Field(alias="exitCode", ge=0)] = None
+    """
+    The process exit code (may be null if terminated by signal).
+    """
+    signal: Optional[str] = None
+    """
+    The signal that terminated the process (may be null if exited normally).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("exit_code", "signal", mode="wrap")
     @classmethod
@@ -2007,35 +2387,33 @@ class TerminalExitStatus(BaseModel):
 
 
 class ReleaseTerminalResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class WaitForTerminalExitResponse(BaseModel):
-    exit_code: Annotated[
-        Optional[int],
-        Field(
-            alias="exitCode",
-            description="The process exit code (may be null if terminated by signal).",
-            ge=0,
-        ),
-    ] = None
-    signal: Annotated[
-        Optional[str],
-        Field(description="The signal that terminated the process (may be null if exited normally)."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    exit_code: Annotated[Optional[int], Field(alias="exitCode", ge=0)] = None
+    """
+    The process exit code (may be null if terminated by signal).
+    """
+    signal: Optional[str] = None
+    """
+    The signal that terminated the process (may be null if exited normally).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("exit_code", "signal", mode="wrap")
     @classmethod
@@ -2044,34 +2422,37 @@ class WaitForTerminalExitResponse(BaseModel):
 
 
 class KillTerminalResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DeclineElicitationResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     action: Literal["decline"]
 
 
 class CancelElicitationResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     action: Literal["cancel"]
 
 
@@ -2079,19 +2460,22 @@ class OtherElicitationResponse(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
-    action: Annotated[
-        str,
-        Field(
-            description="Custom or future elicitation action.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants."
-        ),
-    ]
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
+    action: str
+    """
+    Custom or future elicitation action.
+
+    Values beginning with `_` are reserved for implementation-specific
+    extensions. Unknown values that do not begin with `_` are reserved for
+    future ACP variants.
+    """
 
     @field_validator("action", mode="before")
     @classmethod
@@ -2105,157 +2489,186 @@ class OtherElicitationResponse(BaseModel):
 
 
 class ElicitationContentValue(RootModel[Union[str, int, float, bool, List[str]]]):
-    root: Annotated[
-        Union[str, int, float, bool, List[str]],
-        Field(description="Allowed wire representations for [`ElicitationContentValue`]."),
-    ]
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    root: Union[str, int, float, bool, List[str]]
+    """
+    Allowed wire representations for [`ElicitationContentValue`].
+    """
 
 
 class ElicitationAcceptAction(BaseModel):
-    content: Annotated[
-        Optional[Dict[str, Any]],
-        Field(description="The user-provided content, if any, as an object matching the requested schema."),
-    ] = None
+    content: Optional[Dict[str, Any]] = None
+    """
+    The user-provided content, if any, as an object matching the requested schema.
+    """
 
 
 class ConnectMcpResponse(BaseModel):
-    connection_id: Annotated[
-        str,
-        Field(
-            alias="connectionId",
-            description="The unique identifier for this MCP-over-ACP connection.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    connection_id: Annotated[str, Field(alias="connectionId")]
+    """
+    The unique identifier for this MCP-over-ACP connection.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DisconnectMcpResponse(BaseModel):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CancelNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="The ID of the session to cancel operations for.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to cancel operations for.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DidOpenDocumentNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session ID for this notification."),
-    ]
-    uri: Annotated[str, Field(description="The URI of the opened document.")]
-    language_id: Annotated[
-        str,
-        Field(
-            alias="languageId",
-            description='The language identifier of the document (e.g., "rust", "python").',
-        ),
-    ]
-    version: Annotated[int, Field(description="The version number of the document.")]
-    text: Annotated[str, Field(description="The full text content of the document.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this notification.
+    """
+    uri: str
+    """
+    The URI of the opened document.
+    """
+    language_id: Annotated[str, Field(alias="languageId")]
+    """
+    The language identifier of the document (e.g., "rust", "python").
+    """
+    version: int
+    """
+    The version number of the document.
+    """
+    text: str
+    """
+    The full text content of the document.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DidCloseDocumentNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session ID for this notification."),
-    ]
-    uri: Annotated[str, Field(description="The URI of the closed document.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this notification.
+    """
+    uri: str
+    """
+    The URI of the closed document.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DidSaveDocumentNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session ID for this notification."),
-    ]
-    uri: Annotated[str, Field(description="The URI of the saved document.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this notification.
+    """
+    uri: str
+    """
+    The URI of the saved document.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class AcceptNesNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session ID for this notification."),
-    ]
-    id: Annotated[str, Field(description="The ID of the accepted suggestion.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this notification.
+    """
+    id: str
+    """
+    The ID of the accepted suggestion.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CancelRequestNotification(BaseModel):
-    request_id: Annotated[
-        Optional[Union[int, str]],
-        Field(alias="requestId", description="The ID of the request to cancel."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ]
+    request_id: Annotated[Optional[Union[int, str]], Field(alias="requestId")]
+    """
+    The ID of the request to cancel.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class WriteTextFileRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    path: Annotated[str, Field(description="Absolute path to the file to write.")]
-    content: Annotated[str, Field(description="The text content to write to the file.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    path: str
+    """
+    Absolute path to the file to write.
+    """
+    content: str
+    """
+    The text content to write to the file.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class FileEditToolCallContent(Diff):
@@ -2267,28 +2680,26 @@ class TerminalToolCallContent(Terminal):
 
 
 class Annotations(BaseModel):
-    audience: Annotated[
-        Optional[List[str]],
-        Field(description="Intended recipients for this content, such as the user or assistant."),
-    ] = None
-    last_modified: Annotated[
-        Optional[str],
-        Field(
-            alias="lastModified",
-            description="Timestamp indicating when the underlying resource was last modified.",
-        ),
-    ] = None
-    priority: Annotated[
-        Optional[float],
-        Field(description="Relative importance of this content when clients choose what to surface."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    audience: Optional[List[str]] = None
+    """
+    Intended recipients for this content, such as the user or assistant.
+    """
+    last_modified: Annotated[Optional[str], Field(alias="lastModified")] = None
+    """
+    Timestamp indicating when the underlying resource was last modified.
+    """
+    priority: Optional[float] = None
+    """
+    Relative importance of this content when clients choose what to surface.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("last_modified", "priority", mode="wrap")
     @classmethod
@@ -2302,18 +2713,22 @@ class Annotations(BaseModel):
 
 
 class TextContent(BaseModel):
-    annotations: Annotated[
-        Optional[Annotations],
-        Field(description="Optional annotations that help clients decide how to display or route this content."),
-    ] = None
-    text: Annotated[str, Field(description="Text payload carried by this content block.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    annotations: Optional[Annotations] = None
+    """
+    Optional annotations that help clients decide how to display or route this content.
+    """
+    text: str
+    """
+    Text payload carried by this content block.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("annotations", mode="wrap")
     @classmethod
@@ -2322,29 +2737,30 @@ class TextContent(BaseModel):
 
 
 class ImageContent(BaseModel):
-    annotations: Annotated[
-        Optional[Annotations],
-        Field(description="Optional annotations that help clients decide how to display or route this content."),
-    ] = None
-    data: Annotated[str, Field(description="Base64-encoded media payload.")]
-    mime_type: Annotated[
-        str,
-        Field(
-            alias="mimeType",
-            description="MIME type describing the encoded media payload.",
-        ),
-    ]
-    uri: Annotated[
-        Optional[str],
-        Field(description="URI associated with this resource or media payload."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    annotations: Optional[Annotations] = None
+    """
+    Optional annotations that help clients decide how to display or route this content.
+    """
+    data: str
+    """
+    Base64-encoded media payload.
+    """
+    mime_type: Annotated[str, Field(alias="mimeType")]
+    """
+    MIME type describing the encoded media payload.
+    """
+    uri: Optional[str] = None
+    """
+    URI associated with this resource or media payload.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("annotations", "uri", mode="wrap")
     @classmethod
@@ -2353,25 +2769,26 @@ class ImageContent(BaseModel):
 
 
 class AudioContent(BaseModel):
-    annotations: Annotated[
-        Optional[Annotations],
-        Field(description="Optional annotations that help clients decide how to display or route this content."),
-    ] = None
-    data: Annotated[str, Field(description="Base64-encoded media payload.")]
-    mime_type: Annotated[
-        str,
-        Field(
-            alias="mimeType",
-            description="MIME type describing the encoded media payload.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    annotations: Optional[Annotations] = None
+    """
+    Optional annotations that help clients decide how to display or route this content.
+    """
+    data: str
+    """
+    Base64-encoded media payload.
+    """
+    mime_type: Annotated[str, Field(alias="mimeType")]
+    """
+    MIME type describing the encoded media payload.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("annotations", mode="wrap")
     @classmethod
@@ -2380,35 +2797,42 @@ class AudioContent(BaseModel):
 
 
 class ResourceLink(BaseModel):
-    annotations: Annotated[
-        Optional[Annotations],
-        Field(description="Optional annotations that help clients decide how to display or route this content."),
-    ] = None
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional human-readable details shown with this protocol object."),
-    ] = None
-    mime_type: Annotated[
-        Optional[str],
-        Field(
-            alias="mimeType",
-            description="MIME type describing the encoded media payload.",
-        ),
-    ] = None
-    name: Annotated[str, Field(description="Human-readable name shown for this protocol object.")]
-    size: Annotated[
-        Optional[int],
-        Field(description="Optional size of the linked resource in bytes, if known."),
-    ] = None
-    title: Annotated[Optional[str], Field(description="Optional display title for end-user UI.")] = None
-    uri: Annotated[str, Field(description="URI associated with this resource or media payload.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    annotations: Optional[Annotations] = None
+    """
+    Optional annotations that help clients decide how to display or route this content.
+    """
+    description: Optional[str] = None
+    """
+    Optional human-readable details shown with this protocol object.
+    """
+    mime_type: Annotated[Optional[str], Field(alias="mimeType")] = None
+    """
+    MIME type describing the encoded media payload.
+    """
+    name: str
+    """
+    Human-readable name shown for this protocol object.
+    """
+    size: Optional[int] = None
+    """
+    Optional size of the linked resource in bytes, if known.
+    """
+    title: Optional[str] = None
+    """
+    Optional display title for end-user UI.
+    """
+    uri: str
+    """
+    URI associated with this resource or media payload.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("annotations", "description", "mime_type", "size", "title", mode="wrap")
     @classmethod
@@ -2417,21 +2841,22 @@ class ResourceLink(BaseModel):
 
 
 class EmbeddedResource(BaseModel):
-    annotations: Annotated[
-        Optional[Annotations],
-        Field(description="Optional annotations that help clients decide how to display or route this content."),
-    ] = None
-    resource: Annotated[
-        Union[TextResourceContents, BlobResourceContents],
-        Field(description="Embedded resource payload, either text or binary data."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    annotations: Optional[Annotations] = None
+    """
+    Optional annotations that help clients decide how to display or route this content.
+    """
+    resource: Union[TextResourceContents, BlobResourceContents]
+    """
+    Embedded resource payload, either text or binary data.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("annotations", mode="wrap")
     @classmethod
@@ -2440,51 +2865,68 @@ class EmbeddedResource(BaseModel):
 
 
 class PermissionOption(BaseModel):
-    option_id: Annotated[
-        str,
-        Field(
-            alias="optionId",
-            description="Unique identifier for this permission option.",
-        ),
-    ]
-    name: Annotated[str, Field(description="Human-readable label to display to the user.")]
-    kind: Annotated[PermissionOptionKind, Field(description="Hint about the nature of this permission option.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    option_id: Annotated[str, Field(alias="optionId")]
+    """
+    Unique identifier for this permission option.
+    """
+    name: str
+    """
+    Human-readable label to display to the user.
+    """
+    kind: PermissionOptionKind
+    """
+    Hint about the nature of this permission option.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class CreateTerminalRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    command: Annotated[str, Field(description="The command to execute.")]
-    args: Annotated[Optional[List[str]], Field(description="Array of command arguments.")] = None
-    env: Annotated[
-        Optional[List[EnvVariable]],
-        Field(description="Environment variables for the command."),
-    ] = None
-    cwd: Annotated[
-        Optional[str],
-        Field(description="Working directory for the command. Must be an absolute path."),
-    ] = None
-    output_byte_limit: Annotated[
-        Optional[int],
-        Field(
-            alias="outputByteLimit",
-            description="Maximum number of output bytes to retain.\n\nWhen the limit is exceeded, the Client truncates from the beginning of the output\nto stay within the limit.\n\nThe Client MUST ensure truncation happens at a character boundary to maintain valid\nstring output, even if this means the retained output is slightly less than the\nspecified limit.",
-            ge=0,
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    command: str
+    """
+    The command to execute.
+    """
+    args: Optional[List[str]] = None
+    """
+    Array of command arguments.
+    """
+    env: Optional[List[EnvVariable]] = None
+    """
+    Environment variables for the command.
+    """
+    cwd: Optional[str] = None
+    """
+    Working directory for the command. Must be an absolute path.
+    """
+    output_byte_limit: Annotated[Optional[int], Field(alias="outputByteLimit", ge=0)] = None
+    """
+    Maximum number of output bytes to retain.
+
+    When the limit is exceeded, the Client truncates from the beginning of the output
+    to stay within the limit.
+
+    The Client MUST ensure truncation happens at a character boundary to maintain valid
+    string output, even if this means the retained output is slightly less than the
+    specified limit.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("cwd", "output_byte_limit", mode="wrap")
     @classmethod
@@ -2503,49 +2945,51 @@ class CreateTerminalRequest(BaseModel):
 
 
 class CreateUrlSessionElicitationRequest(ElicitationSessionScope):
-    message: Annotated[
-        str,
-        Field(description="A human-readable message describing what input is needed."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    message: str
+    """
+    A human-readable message describing what input is needed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     mode: Literal["url"]
-    elicitation_id: Annotated[
-        str,
-        Field(
-            alias="elicitationId",
-            description="The unique identifier for this elicitation.",
-        ),
-    ]
-    url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
+    elicitation_id: Annotated[str, Field(alias="elicitationId")]
+    """
+    The unique identifier for this elicitation.
+    """
+    url: AnyUrl
+    """
+    The URL to direct the user to.
+    """
 
 
 class CreateUrlRequestElicitationRequest(ElicitationRequestScope):
-    message: Annotated[
-        str,
-        Field(description="A human-readable message describing what input is needed."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    message: str
+    """
+    A human-readable message describing what input is needed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     mode: Literal["url"]
-    elicitation_id: Annotated[
-        str,
-        Field(
-            alias="elicitationId",
-            description="The unique identifier for this elicitation.",
-        ),
-    ]
-    url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
+    elicitation_id: Annotated[str, Field(alias="elicitationId")]
+    """
+    The unique identifier for this elicitation.
+    """
+    url: AnyUrl
+    """
+    The URL to direct the user to.
+    """
 
 
 class ElicitationStringPropertySchema(StringPropertySchema):
@@ -2569,28 +3013,38 @@ class StringMultiSelectItems(_StringMultiSelectItems):
 
 
 class MultiSelectPropertySchema(BaseModel):
-    title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    min_items: Annotated[
-        Optional[int],
-        Field(alias="minItems", description="Minimum number of items to select.", ge=0),
-    ] = None
-    max_items: Annotated[
-        Optional[int],
-        Field(alias="maxItems", description="Maximum number of items to select.", ge=0),
-    ] = None
-    items: Annotated[
-        Union[StringMultiSelectItems, OtherMultiSelectItems, TitledMultiSelectItems],
-        Field(description="The items definition describing allowed values."),
-    ]
-    default: Annotated[Optional[List[str]], Field(description="Default selected values.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    title: Optional[str] = None
+    """
+    Optional title for the property.
+    """
+    description: Optional[str] = None
+    """
+    Human-readable description.
+    """
+    min_items: Annotated[Optional[int], Field(alias="minItems", ge=0)] = None
+    """
+    Minimum number of items to select.
+    """
+    max_items: Annotated[Optional[int], Field(alias="maxItems", ge=0)] = None
+    """
+    Maximum number of items to select.
+    """
+    items: Union[StringMultiSelectItems, OtherMultiSelectItems, TitledMultiSelectItems]
+    """
+    The items definition describing allowed values.
+    """
+    default: Optional[List[str]] = None
+    """
+    Default selected values.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("description", "title", mode="wrap")
     @classmethod
@@ -2604,91 +3058,108 @@ class MultiSelectPropertySchema(BaseModel):
 
 
 class ConnectMcpRequest(BaseModel):
-    server_id: Annotated[
-        str,
-        Field(
-            alias="serverId",
-            description="The ACP MCP server ID that was provided by the component declaring the MCP server.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    server_id: Annotated[str, Field(alias="serverId")]
+    """
+    The ACP MCP server ID that was provided by the component declaring the MCP server.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class MessageMcpRequest(BaseModel):
-    connection_id: Annotated[
-        str,
-        Field(
-            alias="connectionId",
-            description="The MCP-over-ACP connection this message is sent on.",
-        ),
-    ]
-    method: Annotated[str, Field(description="The inner MCP method name.")]
-    params: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            description="Optional inner MCP params.\n\nIf omitted or set to `null`, the inner MCP message has no params."
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    connection_id: Annotated[str, Field(alias="connectionId")]
+    """
+    The MCP-over-ACP connection this message is sent on.
+    """
+    method: str
+    """
+    The inner MCP method name.
+    """
+    params: Optional[Dict[str, Any]] = None
+    """
+    Optional inner MCP params.
+
+    If omitted or set to `null`, the inner MCP message has no params.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionCapabilities(BaseModel):
-    list: Annotated[
-        Optional[SessionListCapabilities],
-        Field(
-            description="Whether the agent supports `session/list`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports listing sessions."
-        ),
-    ] = None
-    delete: Annotated[
-        Optional[SessionDeleteCapabilities],
-        Field(
-            description="Whether the agent supports `session/delete`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports deleting sessions from `session/list`."
-        ),
-    ] = None
+    list: Optional[SessionListCapabilities] = None
+    """
+    Whether the agent supports `session/list`.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports listing sessions.
+    """
+    delete: Optional[SessionDeleteCapabilities] = None
+    """
+    Whether the agent supports `session/delete`.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports deleting sessions from `session/list`.
+    """
     additional_directories: Annotated[
         Optional[SessionAdditionalDirectoriesCapabilities],
-        Field(
-            alias="additionalDirectories",
-            description="Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports `additionalDirectories` on\nsupported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
-        ),
+        Field(alias="additionalDirectories"),
     ] = None
-    fork: Annotated[
-        Optional[SessionForkCapabilities],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports forking sessions."
-        ),
-    ] = None
-    resume: Annotated[
-        Optional[SessionResumeCapabilities],
-        Field(
-            description="Whether the agent supports `session/resume`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports resuming sessions."
-        ),
-    ] = None
-    close: Annotated[
-        Optional[SessionCloseCapabilities],
-        Field(
-            description="Whether the agent supports `session/close`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports closing sessions."
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports `additionalDirectories` on
+    supported session lifecycle requests.
+
+    Agents that also support `session/list` may return
+    `SessionInfo.additionalDirectories` to report the complete ordered
+    additional-root list associated with a listed session.
+    """
+    fork: Optional[SessionForkCapabilities] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Whether the agent supports `session/fork`.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports forking sessions.
+    """
+    resume: Optional[SessionResumeCapabilities] = None
+    """
+    Whether the agent supports `session/resume`.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports resuming sessions.
+    """
+    close: Optional[SessionCloseCapabilities] = None
+    """
+    Whether the agent supports `session/close`.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports closing sessions.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("additional_directories", "close", "delete", "fork", "list", "resume", mode="wrap")
     @classmethod
@@ -2697,19 +3168,21 @@ class SessionCapabilities(BaseModel):
 
 
 class AgentAuthCapabilities(BaseModel):
-    logout: Annotated[
-        Optional[LogoutCapabilities],
-        Field(
-            description="Whether the agent supports the logout method.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports the logout method."
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    logout: Optional[LogoutCapabilities] = None
+    """
+    Whether the agent supports the logout method.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports the logout method.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("logout", mode="wrap")
     @classmethod
@@ -2718,66 +3191,53 @@ class AgentAuthCapabilities(BaseModel):
 
 
 class NesDocumentDidChangeCapabilities(BaseModel):
-    sync_kind: Annotated[
-        str,
-        Field(
-            alias="syncKind",
-            description='The sync kind the agent wants: `"full"` or `"incremental"`.',
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    sync_kind: Annotated[str, Field(alias="syncKind")]
+    """
+    The sync kind the agent wants: `"full"` or `"incremental"`.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesContextCapabilities(BaseModel):
-    recent_files: Annotated[
-        Optional[NesRecentFilesCapabilities],
-        Field(
-            alias="recentFiles",
-            description="Whether the agent wants recent files context.",
-        ),
-    ] = None
-    related_snippets: Annotated[
-        Optional[NesRelatedSnippetsCapabilities],
-        Field(
-            alias="relatedSnippets",
-            description="Whether the agent wants related snippets context.",
-        ),
-    ] = None
-    edit_history: Annotated[
-        Optional[NesEditHistoryCapabilities],
-        Field(
-            alias="editHistory",
-            description="Whether the agent wants edit history context.",
-        ),
-    ] = None
-    user_actions: Annotated[
-        Optional[NesUserActionsCapabilities],
-        Field(
-            alias="userActions",
-            description="Whether the agent wants user actions context.",
-        ),
-    ] = None
-    open_files: Annotated[
-        Optional[NesOpenFilesCapabilities],
-        Field(alias="openFiles", description="Whether the agent wants open files context."),
-    ] = None
-    diagnostics: Annotated[
-        Optional[NesDiagnosticsCapabilities],
-        Field(description="Whether the agent wants diagnostics context."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    recent_files: Annotated[Optional[NesRecentFilesCapabilities], Field(alias="recentFiles")] = None
+    """
+    Whether the agent wants recent files context.
+    """
+    related_snippets: Annotated[Optional[NesRelatedSnippetsCapabilities], Field(alias="relatedSnippets")] = None
+    """
+    Whether the agent wants related snippets context.
+    """
+    edit_history: Annotated[Optional[NesEditHistoryCapabilities], Field(alias="editHistory")] = None
+    """
+    Whether the agent wants edit history context.
+    """
+    user_actions: Annotated[Optional[NesUserActionsCapabilities], Field(alias="userActions")] = None
+    """
+    Whether the agent wants user actions context.
+    """
+    open_files: Annotated[Optional[NesOpenFilesCapabilities], Field(alias="openFiles")] = None
+    """
+    Whether the agent wants open files context.
+    """
+    diagnostics: Optional[NesDiagnosticsCapabilities] = None
+    """
+    Whether the agent wants diagnostics context.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator(
         "diagnostics", "edit_history", "open_files", "recent_files", "related_snippets", "user_actions", mode="wrap"
@@ -2796,43 +3256,41 @@ class TerminalAuthMethod(AuthMethodTerminal):
 
 
 class ProviderInfo(BaseModel):
-    provider_id: Annotated[
-        str,
-        Field(
-            alias="providerId",
-            description='Provider identifier, for example "main" or "openai".',
-        ),
+    provider_id: Annotated[str, Field(alias="providerId")]
+    """
+    Provider identifier, for example "main" or "openai".
+    """
+    supported: List[
+        Union[
+            Literal["anthropic"],
+            Literal["openai"],
+            Literal["azure"],
+            Literal["vertex"],
+            Literal["bedrock"],
+            Dict[str, Any],
+        ]
     ]
-    supported: Annotated[
-        List[
-            Union[
-                Literal["anthropic"],
-                Literal["openai"],
-                Literal["azure"],
-                Literal["vertex"],
-                Literal["bedrock"],
-                Dict[str, Any],
-            ]
-        ],
-        Field(description="Supported protocol types for this provider."),
-    ]
-    required: Annotated[
-        bool,
-        Field(
-            description="Whether this provider is mandatory and cannot be disabled via `providers/disable`.\nIf true, clients must not call `providers/disable` for this provider ID."
-        ),
-    ]
-    current: Annotated[
-        Optional[ProviderCurrentConfig],
-        Field(description="Current effective non-secret routing config.\nNull or omitted means provider is disabled."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Supported protocol types for this provider.
+    """
+    required: bool
+    """
+    Whether this provider is mandatory and cannot be disabled via `providers/disable`.
+    If true, clients must not call `providers/disable` for this provider ID.
+    """
+    current: Optional[ProviderCurrentConfig] = None
+    """
+    Current effective non-secret routing config.
+    Null or omitted means provider is disabled.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("supported", mode="wrap")
     @classmethod
@@ -2841,24 +3299,22 @@ class ProviderInfo(BaseModel):
 
 
 class SessionModeState(BaseModel):
-    current_mode_id: Annotated[
-        str,
-        Field(alias="currentModeId", description="The current mode the Agent is in."),
-    ]
-    available_modes: Annotated[
-        List[SessionMode],
-        Field(
-            alias="availableModes",
-            description="The set of modes that the Agent can operate in",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    current_mode_id: Annotated[str, Field(alias="currentModeId")]
+    """
+    The current mode the Agent is in.
+    """
+    available_modes: Annotated[List[SessionMode], Field(alias="availableModes")]
+    """
+    The set of modes that the Agent can operate in
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("available_modes", mode="wrap")
     @classmethod
@@ -2867,31 +3323,38 @@ class SessionModeState(BaseModel):
 
 
 class SessionConfigOptionBoolean(SessionConfigBoolean):
-    id: Annotated[str, Field(description="Unique identifier for the configuration option.")]
-    name: Annotated[str, Field(description="Human-readable label for the option.")]
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional description for the Client to display to the user."),
+    id: str
+    """
+    Unique identifier for the configuration option.
+    """
+    name: str
+    """
+    Human-readable label for the option.
+    """
+    description: Optional[str] = None
+    """
+    Optional description for the Client to display to the user.
+    """
+    category: Optional[
+        Union[
+            Literal["mode"],
+            Literal["model"],
+            Literal["model_config"],
+            Literal["thought_level"],
+            Dict[str, Any],
+        ]
     ] = None
-    category: Annotated[
-        Optional[
-            Union[
-                Literal["mode"],
-                Literal["model"],
-                Literal["model_config"],
-                Literal["thought_level"],
-                Dict[str, Any],
-            ]
-        ],
-        Field(description="Optional semantic category for this option (UX only)."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Optional semantic category for this option (UX only).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     type: Literal["boolean"]
 
     @field_validator("category", "description", mode="wrap")
@@ -2901,19 +3364,26 @@ class SessionConfigOptionBoolean(SessionConfigBoolean):
 
 
 class SessionConfigSelectGroup(BaseModel):
-    group: Annotated[str, Field(description="Unique identifier for this group.")]
-    name: Annotated[str, Field(description="Human-readable label for this group.")]
-    options: Annotated[
-        List[SessionConfigSelectOption],
-        Field(description="The set of option values in this group."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    group: str
+    """
+    Unique identifier for this group.
+    """
+    name: str
+    """
+    Human-readable label for this group.
+    """
+    options: List[SessionConfigSelectOption]
+    """
+    The set of option values in this group.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("options", mode="wrap")
     @classmethod
@@ -2922,21 +3392,23 @@ class SessionConfigSelectGroup(BaseModel):
 
 
 class ListSessionsResponse(BaseModel):
-    sessions: Annotated[List[SessionInfo], Field(description="Array of session information objects")]
-    next_cursor: Annotated[
-        Optional[str],
-        Field(
-            alias="nextCursor",
-            description="Opaque cursor token. If present, pass this in the next request's cursor parameter\nto fetch the next page. If absent, there are no more results.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    sessions: List[SessionInfo]
+    """
+    Array of session information objects
+    """
+    next_cursor: Annotated[Optional[str], Field(alias="nextCursor")] = None
+    """
+    Opaque cursor token. If present, pass this in the next request's cursor parameter
+    to fetch the next page. If absent, there are no more results.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("next_cursor", mode="wrap")
     @classmethod
@@ -2950,26 +3422,26 @@ class ListSessionsResponse(BaseModel):
 
 
 class PromptResponse(BaseModel):
-    stop_reason: Annotated[
-        StopReason,
-        Field(
-            alias="stopReason",
-            description="Indicates why the agent stopped processing the turn.",
-        ),
-    ]
-    usage: Annotated[
-        Optional[Usage],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nToken usage for this turn (optional)."
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    stop_reason: Annotated[StopReason, Field(alias="stopReason")]
+    """
+    Indicates why the agent stopped processing the turn.
+    """
+    usage: Optional[Usage] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Token usage for this turn (optional).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("usage", mode="wrap")
     @classmethod
@@ -2990,46 +3462,50 @@ class NesSearchAndReplaceSuggestionVariant(NesSearchAndReplaceSuggestion):
 
 
 class Range(BaseModel):
-    start: Annotated[Position, Field(description="The start position (inclusive).")]
-    end: Annotated[Position, Field(description="The end position (exclusive).")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    start: Position
+    """
+    The start position (inclusive).
+    """
+    end: Position
+    """
+    The end position (exclusive).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class Error(BaseModel):
-    code: Annotated[
-        Union[
-            Literal[-32700],
-            Literal[-32600],
-            Literal[-32601],
-            Literal[-32602],
-            Literal[-32603],
-            Literal[-32800],
-            Literal[-32000],
-            Literal[-32002],
-            int,
-        ],
-        Field(
-            description="A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
-        ),
+    code: Union[
+        Literal[-32700],
+        Literal[-32600],
+        Literal[-32601],
+        Literal[-32602],
+        Literal[-32603],
+        Literal[-32800],
+        Literal[-32000],
+        Literal[-32002],
+        int,
     ]
-    message: Annotated[
-        str,
-        Field(
-            description="A string providing a short description of the error.\nThe message should be limited to a concise single sentence."
-        ),
-    ]
-    data: Annotated[
-        Optional[Any],
-        Field(
-            description="Optional primitive or structured value that contains additional information about the error.\nThis may include debugging information or context-specific details."
-        ),
-    ] = None
+    """
+    A number indicating the error type that occurred.
+    This must be an integer as defined in the JSON-RPC specification.
+    """
+    message: str
+    """
+    A string providing a short description of the error.
+    The message should be limited to a concise single sentence.
+    """
+    data: Optional[Any] = None
+    """
+    Optional primitive or structured value that contains additional information about the error.
+    This may include debugging information or context-specific details.
+    """
 
     @field_validator("data", mode="wrap")
     @classmethod
@@ -3054,40 +3530,45 @@ class UsageUpdate(_UsageUpdate):
 
 
 class PlanEntry(BaseModel):
-    content: Annotated[
-        str,
-        Field(description="Human-readable description of what this task aims to accomplish."),
-    ]
-    priority: Annotated[
-        PlanEntryPriority,
-        Field(
-            description="The relative importance of this task.\nUsed to indicate which tasks are most critical to the overall goal."
-        ),
-    ]
-    status: Annotated[PlanEntryStatus, Field(description="Current execution status of this task.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    content: str
+    """
+    Human-readable description of what this task aims to accomplish.
+    """
+    priority: PlanEntryPriority
+    """
+    The relative importance of this task.
+    Used to indicate which tasks are most critical to the overall goal.
+    """
+    status: PlanEntryStatus
+    """
+    Current execution status of this task.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class Plan(BaseModel):
-    entries: Annotated[
-        List[PlanEntry],
-        Field(
-            description="The list of tasks to be accomplished.\n\nWhen updating a plan, the agent must send a complete list of all entries\nwith their current status. The client replaces the entire plan with each update."
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    entries: List[PlanEntry]
+    """
+    The list of tasks to be accomplished.
+
+    When updating a plan, the agent must send a complete list of all entries
+    with their current status. The client replaces the entire plan with each update.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("entries", mode="wrap")
     @classmethod
@@ -3104,20 +3585,25 @@ class PlanUpdateMarkdown(PlanMarkdown):
 
 
 class PlanItems(BaseModel):
-    plan_id: Annotated[str, Field(alias="planId", description="The plan ID to update.")]
-    entries: Annotated[
-        List[PlanEntry],
-        Field(
-            description="The list of tasks to be accomplished.\n\nWhen updating an item-based plan, the agent must send a complete list of all entries\nwith their current status. The client replaces that plan with each update."
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    plan_id: Annotated[str, Field(alias="planId")]
+    """
+    The plan ID to update.
+    """
+    entries: List[PlanEntry]
+    """
+    The list of tasks to be accomplished.
+
+    When updating an item-based plan, the agent must send a complete list of all entries
+    with their current status. The client replaces that plan with each update.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("entries", mode="wrap")
     @classmethod
@@ -3126,26 +3612,32 @@ class PlanItems(BaseModel):
 
 
 class AvailableCommandInput(RootModel[UnstructuredCommandInput]):
-    root: Annotated[
-        UnstructuredCommandInput,
-        Field(description="The input specification for a command."),
-    ]
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    root: UnstructuredCommandInput
+    """
+    The input specification for a command.
+    """
 
 
 class SessionConfigOptionsCapabilities(BaseModel):
-    boolean: Annotated[
-        Optional[BooleanConfigOptionCapabilities],
-        Field(
-            description='Whether the client supports boolean session configuration options.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means agents may include `type: "boolean"` entries in\n`configOptions`, and the client may send `session/set_config_option`\nrequests with `type: "boolean"` and a boolean `value`.'
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    boolean: Optional[BooleanConfigOptionCapabilities] = None
+    """
+    Whether the client supports boolean session configuration options.
+
+    Optional. Omitted or `null` both mean the client does not advertise support.
+    Supplying `{}` means agents may include `type: "boolean"` entries in
+    `configOptions`, and the client may send `session/set_config_option`
+    requests with `type: "boolean"` and a boolean `value`.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("boolean", mode="wrap")
     @classmethod
@@ -3154,25 +3646,28 @@ class SessionConfigOptionsCapabilities(BaseModel):
 
 
 class ElicitationCapabilities(BaseModel):
-    form: Annotated[
-        Optional[ElicitationFormCapabilities],
-        Field(
-            description="Whether the client supports form-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports form-based elicitation."
-        ),
-    ] = None
-    url: Annotated[
-        Optional[ElicitationUrlCapabilities],
-        Field(
-            description="Whether the client supports URL-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports URL-based elicitation."
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    form: Optional[ElicitationFormCapabilities] = None
+    """
+    Whether the client supports form-based elicitation.
+
+    Optional. Omitted or `null` both mean the client does not advertise support.
+    Supplying `{}` means the client supports form-based elicitation.
+    """
+    url: Optional[ElicitationUrlCapabilities] = None
+    """
+    Whether the client supports URL-based elicitation.
+
+    Optional. Omitted or `null` both mean the client does not advertise support.
+    Supplying `{}` means the client supports URL-based elicitation.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("form", "url", mode="wrap")
     @classmethod
@@ -3181,28 +3676,26 @@ class ElicitationCapabilities(BaseModel):
 
 
 class ClientNesCapabilities(BaseModel):
-    jump: Annotated[
-        Optional[NesJumpCapabilities],
-        Field(description="Whether the client supports the `jump` suggestion kind."),
-    ] = None
-    rename: Annotated[
-        Optional[NesRenameCapabilities],
-        Field(description="Whether the client supports the `rename` suggestion kind."),
-    ] = None
-    search_and_replace: Annotated[
-        Optional[NesSearchAndReplaceCapabilities],
-        Field(
-            alias="searchAndReplace",
-            description="Whether the client supports the `searchAndReplace` suggestion kind.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    jump: Optional[NesJumpCapabilities] = None
+    """
+    Whether the client supports the `jump` suggestion kind.
+    """
+    rename: Optional[NesRenameCapabilities] = None
+    """
+    Whether the client supports the `rename` suggestion kind.
+    """
+    search_and_replace: Annotated[Optional[NesSearchAndReplaceCapabilities], Field(alias="searchAndReplace")] = None
+    """
+    Whether the client supports the `searchAndReplace` suggestion kind.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("jump", "rename", "search_and_replace", mode="wrap")
     @classmethod
@@ -3225,30 +3718,36 @@ class AcpMcpServer(McpServerAcp):
 class LoadSessionRequest(BaseModel):
     mcp_servers: Annotated[
         List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]],
-        Field(
-            alias="mcpServers",
-            description="List of MCP servers to connect to for this session.",
-        ),
+        Field(alias="mcpServers"),
     ]
-    cwd: Annotated[
-        str,
-        Field(description="The working directory for this session. Must be an absolute path."),
-    ]
-    additional_directories: Annotated[
-        Optional[List[str]],
-        Field(
-            alias="additionalDirectories",
-            description="Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
-        ),
-    ] = None
-    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to load.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    List of MCP servers to connect to for this session.
+    """
+    cwd: str
+    """
+    The working directory for this session. Must be an absolute path.
+    """
+    additional_directories: Annotated[Optional[List[str]], Field(alias="additionalDirectories")] = None
+    """
+    Additional workspace roots to activate for this session. Each path must be absolute.
+
+    When omitted or empty, no additional roots are activated. When non-empty,
+    this is the complete resulting additional-root list for the loaded
+    session. It may differ from any previously used or reported list as long as
+    the request `cwd` matches the session's `cwd`.
+    """
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to load.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("additional_directories", mode="wrap")
     @classmethod
@@ -3262,32 +3761,37 @@ class LoadSessionRequest(BaseModel):
 
 
 class ForkSessionRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to fork.")]
-    cwd: Annotated[
-        str,
-        Field(description="The working directory for this session. Must be an absolute path."),
-    ]
-    additional_directories: Annotated[
-        Optional[List[str]],
-        Field(
-            alias="additionalDirectories",
-            description="Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the forked\nsession.",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to fork.
+    """
+    cwd: str
+    """
+    The working directory for this session. Must be an absolute path.
+    """
+    additional_directories: Annotated[Optional[List[str]], Field(alias="additionalDirectories")] = None
+    """
+    Additional workspace roots to activate for this session. Each path must be absolute.
+
+    When omitted or empty, no additional roots are activated. When non-empty,
+    this is the complete resulting additional-root list for the forked
+    session.
+    """
     mcp_servers: Annotated[
         Optional[List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]]],
-        Field(
-            alias="mcpServers",
-            description="List of MCP servers to connect to for this session.",
-        ),
+        Field(alias="mcpServers"),
     ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    List of MCP servers to connect to for this session.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("additional_directories", mode="wrap")
     @classmethod
@@ -3301,32 +3805,38 @@ class ForkSessionRequest(BaseModel):
 
 
 class ResumeSessionRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to resume.")]
-    cwd: Annotated[
-        str,
-        Field(description="The working directory for this session. Must be an absolute path."),
-    ]
-    additional_directories: Annotated[
-        Optional[List[str]],
-        Field(
-            alias="additionalDirectories",
-            description="Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to resume.
+    """
+    cwd: str
+    """
+    The working directory for this session. Must be an absolute path.
+    """
+    additional_directories: Annotated[Optional[List[str]], Field(alias="additionalDirectories")] = None
+    """
+    Additional workspace roots to activate for this session. Each path must be absolute.
+
+    When omitted or empty, no additional roots are activated. When non-empty,
+    this is the complete resulting additional-root list for the resumed
+    session. It may differ from any previously used or reported list as long as
+    the request `cwd` matches the session's `cwd`.
+    """
     mcp_servers: Annotated[
         Optional[List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]]],
-        Field(
-            alias="mcpServers",
-            description="List of MCP servers to connect to for this session.",
-        ),
+        Field(alias="mcpServers"),
     ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    List of MCP servers to connect to for this session.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("additional_directories", mode="wrap")
     @classmethod
@@ -3340,25 +3850,26 @@ class ResumeSessionRequest(BaseModel):
 
 
 class StartNesRequest(BaseModel):
-    workspace_uri: Annotated[
-        Optional[str],
-        Field(alias="workspaceUri", description="The root URI of the workspace."),
-    ] = None
-    workspace_folders: Annotated[
-        Optional[List[WorkspaceFolder]],
-        Field(alias="workspaceFolders", description="The workspace folders."),
-    ] = None
-    repository: Annotated[
-        Optional[NesRepository],
-        Field(description="Repository metadata, if the workspace is a git repository."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    workspace_uri: Annotated[Optional[str], Field(alias="workspaceUri")] = None
+    """
+    The root URI of the workspace.
+    """
+    workspace_folders: Annotated[Optional[List[WorkspaceFolder]], Field(alias="workspaceFolders")] = None
+    """
+    The workspace folders.
+    """
+    repository: Optional[NesRepository] = None
+    """
+    Repository metadata, if the workspace is a git repository.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("repository", "workspace_uri", mode="wrap")
     @classmethod
@@ -3367,39 +3878,49 @@ class StartNesRequest(BaseModel):
 
 
 class NesRelatedSnippet(BaseModel):
-    uri: Annotated[str, Field(description="The URI of the file containing the snippets.")]
-    excerpts: Annotated[List[NesExcerpt], Field(description="The code excerpts.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    uri: str
+    """
+    The URI of the file containing the snippets.
+    """
+    excerpts: List[NesExcerpt]
+    """
+    The code excerpts.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesOpenFile(BaseModel):
-    uri: Annotated[str, Field(description="The URI of the file.")]
-    language_id: Annotated[str, Field(alias="languageId", description="The language identifier.")]
-    visible_range: Annotated[
-        Optional[Range],
-        Field(alias="visibleRange", description="The visible range in the editor, if any."),
-    ] = None
-    last_focused_ms: Annotated[
-        Optional[int],
-        Field(
-            alias="lastFocusedMs",
-            description="Timestamp in milliseconds since epoch of when the file was last focused.",
-            ge=0,
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    uri: str
+    """
+    The URI of the file.
+    """
+    language_id: Annotated[str, Field(alias="languageId")]
+    """
+    The language identifier.
+    """
+    visible_range: Annotated[Optional[Range], Field(alias="visibleRange")] = None
+    """
+    The visible range in the editor, if any.
+    """
+    last_focused_ms: Annotated[Optional[int], Field(alias="lastFocusedMs", ge=0)] = None
+    """
+    Timestamp in milliseconds since epoch of when the file was last focused.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("last_focused_ms", "visible_range", mode="wrap")
     @classmethod
@@ -3408,25 +3929,41 @@ class NesOpenFile(BaseModel):
 
 
 class NesDiagnostic(BaseModel):
-    uri: Annotated[str, Field(description="The URI of the file containing the diagnostic.")]
-    range: Annotated[Range, Field(description="The range of the diagnostic.")]
-    severity: Annotated[str, Field(description="The severity of the diagnostic.")]
-    message: Annotated[str, Field(description="The diagnostic message.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    uri: str
+    """
+    The URI of the file containing the diagnostic.
+    """
+    range: Range
+    """
+    The range of the diagnostic.
+    """
+    severity: str
+    """
+    The severity of the diagnostic.
+    """
+    message: str
+    """
+    The diagnostic message.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ClientErrorMessage(BaseModel):
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(description="The id of the request this response answers."),
-    ]
-    error: Annotated[Error, Field(description="Method-specific error data.")]
+    id: Optional[Union[int, str]]
+    """
+    The id of the request this response answers.
+    """
+    error: Error
+    """
+    Method-specific error data.
+    """
 
 
 class AllowedOutcome(SelectedPermissionOutcome):
@@ -3434,19 +3971,26 @@ class AllowedOutcome(SelectedPermissionOutcome):
 
 
 class TerminalOutputResponse(BaseModel):
-    output: Annotated[str, Field(description="The terminal output captured so far.")]
-    truncated: Annotated[bool, Field(description="Whether the output was truncated due to byte limits.")]
-    exit_status: Annotated[
-        Optional[TerminalExitStatus],
-        Field(alias="exitStatus", description="Exit status if the command has completed."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    output: str
+    """
+    The terminal output captured so far.
+    """
+    truncated: bool
+    """
+    Whether the output was truncated due to byte limits.
+    """
+    exit_status: Annotated[Optional[TerminalExitStatus], Field(alias="exitStatus")] = None
+    """
+    Exit status if the command has completed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("exit_status", mode="wrap")
     @classmethod
@@ -3455,72 +3999,88 @@ class TerminalOutputResponse(BaseModel):
 
 
 class AcceptElicitationResponse(ElicitationAcceptAction):
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     action: Literal["accept"]
 
 
 class TextDocumentContentChangeEvent(BaseModel):
-    range: Annotated[
-        Optional[Range],
-        Field(description="The range of the document that changed. If `None`, the entire content is replaced."),
-    ] = None
-    text: Annotated[
-        str,
-        Field(description="The new text for the range, or the full document content if `range` is `None`."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    range: Optional[Range] = None
+    """
+    The range of the document that changed. If `None`, the entire content is replaced.
+    """
+    text: str
+    """
+    The new text for the range, or the full document content if `range` is `None`.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DidFocusDocumentNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session ID for this notification."),
-    ]
-    uri: Annotated[str, Field(description="The URI of the focused document.")]
-    version: Annotated[int, Field(description="The version number of the document.")]
-    position: Annotated[Position, Field(description="The current cursor position.")]
-    visible_range: Annotated[
-        Range,
-        Field(
-            alias="visibleRange",
-            description="The portion of the file currently visible in the editor viewport.",
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this notification.
+    """
+    uri: str
+    """
+    The URI of the focused document.
+    """
+    version: int
+    """
+    The version number of the document.
+    """
+    position: Position
+    """
+    The current cursor position.
+    """
+    visible_range: Annotated[Range, Field(alias="visibleRange")]
+    """
+    The portion of the file currently visible in the editor viewport.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class RejectNesNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session ID for this notification."),
-    ]
-    id: Annotated[str, Field(description="The ID of the rejected suggestion.")]
-    reason: Annotated[Optional[str], Field(description="The reason for rejection.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this notification.
+    """
+    id: str
+    """
+    The ID of the rejected suggestion.
+    """
+    reason: Optional[str] = None
+    """
+    The reason for rejection.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("reason", mode="wrap")
     @classmethod
@@ -3553,15 +4113,19 @@ class Content(BaseModel):
         Union[
             TextContentBlock, ImageContentBlock, AudioContentBlock, ResourceContentBlock, EmbeddedResourceContentBlock
         ],
-        Field(description="The actual content block.", discriminator="type"),
+        Field(discriminator="type"),
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The actual content block.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ElicitationMultiSelectPropertySchema(MultiSelectPropertySchema):
@@ -3569,56 +4133,45 @@ class ElicitationMultiSelectPropertySchema(MultiSelectPropertySchema):
 
 
 class AgentErrorMessage(BaseModel):
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(description="The id of the request this response answers."),
-    ]
-    error: Annotated[Error, Field(description="Method-specific error data.")]
+    id: Optional[Union[int, str]]
+    """
+    The id of the request this response answers.
+    """
+    error: Error
+    """
+    Method-specific error data.
+    """
 
 
 class NesDocumentEventCapabilities(BaseModel):
-    did_open: Annotated[
-        Optional[NesDocumentDidOpenCapabilities],
-        Field(
-            alias="didOpen",
-            description="Whether the agent wants `document/didOpen` events.",
-        ),
-    ] = None
-    did_change: Annotated[
-        Optional[NesDocumentDidChangeCapabilities],
-        Field(
-            alias="didChange",
-            description="Whether the agent wants `document/didChange` events, and the sync kind.",
-        ),
-    ] = None
-    did_close: Annotated[
-        Optional[NesDocumentDidCloseCapabilities],
-        Field(
-            alias="didClose",
-            description="Whether the agent wants `document/didClose` events.",
-        ),
-    ] = None
-    did_save: Annotated[
-        Optional[NesDocumentDidSaveCapabilities],
-        Field(
-            alias="didSave",
-            description="Whether the agent wants `document/didSave` events.",
-        ),
-    ] = None
-    did_focus: Annotated[
-        Optional[NesDocumentDidFocusCapabilities],
-        Field(
-            alias="didFocus",
-            description="Whether the agent wants `document/didFocus` events.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    did_open: Annotated[Optional[NesDocumentDidOpenCapabilities], Field(alias="didOpen")] = None
+    """
+    Whether the agent wants `document/didOpen` events.
+    """
+    did_change: Annotated[Optional[NesDocumentDidChangeCapabilities], Field(alias="didChange")] = None
+    """
+    Whether the agent wants `document/didChange` events, and the sync kind.
+    """
+    did_close: Annotated[Optional[NesDocumentDidCloseCapabilities], Field(alias="didClose")] = None
+    """
+    Whether the agent wants `document/didClose` events.
+    """
+    did_save: Annotated[Optional[NesDocumentDidSaveCapabilities], Field(alias="didSave")] = None
+    """
+    Whether the agent wants `document/didSave` events.
+    """
+    did_focus: Annotated[Optional[NesDocumentDidFocusCapabilities], Field(alias="didFocus")] = None
+    """
+    Whether the agent wants `document/didFocus` events.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("did_change", "did_close", "did_focus", "did_open", "did_save", mode="wrap")
     @classmethod
@@ -3627,57 +4180,75 @@ class NesDocumentEventCapabilities(BaseModel):
 
 
 class ListProvidersResponse(BaseModel):
-    providers: Annotated[
-        List[ProviderInfo],
-        Field(description="Configurable providers with current routing info suitable for UI display."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    providers: List[ProviderInfo]
+    """
+    Configurable providers with current routing info suitable for UI display.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class SessionConfigSelect(BaseModel):
-    current_value: Annotated[str, Field(alias="currentValue", description="The currently selected value.")]
-    options: Annotated[
-        Union[List[SessionConfigSelectOption], List[SessionConfigSelectGroup]],
-        Field(description="The set of selectable options."),
-    ]
+    current_value: Annotated[str, Field(alias="currentValue")]
+    """
+    The currently selected value.
+    """
+    options: Union[List[SessionConfigSelectOption], List[SessionConfigSelectGroup]]
+    """
+    The set of selectable options.
+    """
 
 
 class NesTextEdit(BaseModel):
-    range: Annotated[Range, Field(description="The range to replace.")]
-    new_text: Annotated[str, Field(alias="newText", description="The replacement text.")]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    range: Range
+    """
+    The range to replace.
+    """
+    new_text: Annotated[str, Field(alias="newText")]
+    """
+    The replacement text.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesEditSuggestion(BaseModel):
-    id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    uri: Annotated[str, Field(description="The URI of the file to edit.")]
-    edits: Annotated[List[NesTextEdit], Field(description="The text edits to apply.")]
-    cursor_position: Annotated[
-        Optional[Position],
-        Field(
-            alias="cursorPosition",
-            description="Optional suggested cursor position after applying edits.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    id: str
+    """
+    Unique identifier for accept/reject tracking.
+    """
+    uri: str
+    """
+    The URI of the file to edit.
+    """
+    edits: List[NesTextEdit]
+    """
+    The text edits to apply.
+    """
+    cursor_position: Annotated[Optional[Position], Field(alias="cursorPosition")] = None
+    """
+    Optional suggested cursor position after applying edits.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("cursor_position", mode="wrap")
     @classmethod
@@ -3694,22 +4265,26 @@ class ContentChunk(BaseModel):
         Union[
             TextContentBlock, ImageContentBlock, AudioContentBlock, ResourceContentBlock, EmbeddedResourceContentBlock
         ],
-        Field(description="A single item of content", discriminator="type"),
+        Field(discriminator="type"),
     ]
-    message_id: Annotated[
-        Optional[str],
-        Field(
-            alias="messageId",
-            description="A unique identifier for the message this chunk belongs to.\n\nAll chunks belonging to the same message share the same `messageId`.\nA change in `messageId` indicates a new message has started.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    A single item of content
+    """
+    message_id: Annotated[Optional[str], Field(alias="messageId")] = None
+    """
+    A unique identifier for the message this chunk belongs to.
+
+    All chunks belonging to the same message share the same `messageId`.
+    A change in `messageId` indicates a new message has started.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("message_id", mode="wrap")
     @classmethod
@@ -3724,34 +4299,42 @@ class PlanUpdateItems(PlanItems):
 class PlanUpdate(BaseModel):
     plan: Annotated[
         Union[PlanUpdateItems, PlanUpdateFile, PlanUpdateMarkdown],
-        Field(description="The updated plan content.", discriminator="type"),
+        Field(discriminator="type"),
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The updated plan content.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class AvailableCommand(BaseModel):
-    name: Annotated[
-        str,
-        Field(description="Command name (e.g., `create_plan`, `research_codebase`)."),
-    ]
-    description: Annotated[str, Field(description="Human-readable description of what the command does.")]
-    input: Annotated[
-        Optional[AvailableCommandInput],
-        Field(description="Input for the command if required"),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    name: str
+    """
+    Command name (e.g., `create_plan`, `research_codebase`).
+    """
+    description: str
+    """
+    Human-readable description of what the command does.
+    """
+    input: Optional[AvailableCommandInput] = None
+    """
+    Input for the command if required
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("input", mode="wrap")
     @classmethod
@@ -3760,17 +4343,18 @@ class AvailableCommand(BaseModel):
 
 
 class _AvailableCommandsUpdate(BaseModel):
-    available_commands: Annotated[
-        List[AvailableCommand],
-        Field(alias="availableCommands", description="Commands the agent can execute"),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    available_commands: Annotated[List[AvailableCommand], Field(alias="availableCommands")]
+    """
+    Commands the agent can execute
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("available_commands", mode="wrap")
     @classmethod
@@ -3779,20 +4363,21 @@ class _AvailableCommandsUpdate(BaseModel):
 
 
 class ClientSessionCapabilities(BaseModel):
-    config_options: Annotated[
-        Optional[SessionConfigOptionsCapabilities],
-        Field(
-            alias="configOptions",
-            description="Config option capabilities supported by the client.\n\nOmitted or `null` both mean the client does not advertise support for any\nconfig option extensions.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    config_options: Annotated[Optional[SessionConfigOptionsCapabilities], Field(alias="configOptions")] = None
+    """
+    Config option capabilities supported by the client.
+
+    Omitted or `null` both mean the client does not advertise support for any
+    config option extensions.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("config_options", mode="wrap")
     @classmethod
@@ -3801,31 +4386,33 @@ class ClientSessionCapabilities(BaseModel):
 
 
 class NewSessionRequest(BaseModel):
-    cwd: Annotated[
-        str,
-        Field(description="The working directory for this session. Must be an absolute path."),
-    ]
-    additional_directories: Annotated[
-        Optional[List[str]],
-        Field(
-            alias="additionalDirectories",
-            description="Additional workspace roots for this session. Each path must be absolute.\n\nThese expand the session's filesystem scope without changing `cwd`, which\nremains the base for relative paths. When omitted or empty, no\nadditional roots are activated for the new session.",
-        ),
-    ] = None
+    cwd: str
+    """
+    The working directory for this session. Must be an absolute path.
+    """
+    additional_directories: Annotated[Optional[List[str]], Field(alias="additionalDirectories")] = None
+    """
+    Additional workspace roots for this session. Each path must be absolute.
+
+    These expand the session's filesystem scope without changing `cwd`, which
+    remains the base for relative paths. When omitted or empty, no
+    additional roots are activated for the new session.
+    """
     mcp_servers: Annotated[
         List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]],
-        Field(
-            alias="mcpServers",
-            description="List of MCP (Model Context Protocol) servers the agent should connect to.",
-        ),
+        Field(alias="mcpServers"),
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    List of MCP (Model Context Protocol) servers the agent should connect to.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("additional_directories", mode="wrap")
     @classmethod
@@ -3839,111 +4426,125 @@ class NewSessionRequest(BaseModel):
 
 
 class PromptRequest(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="The ID of the session to send this user message to",
-        ),
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session to send this user message to
+    """
+    prompt: List[
+        Annotated[
+            Union[
+                TextContentBlock,
+                ImageContentBlock,
+                AudioContentBlock,
+                ResourceContentBlock,
+                EmbeddedResourceContentBlock,
+            ],
+            Field(discriminator="type"),
+        ]
     ]
-    prompt: Annotated[
-        List[
-            Annotated[
-                Union[
-                    TextContentBlock,
-                    ImageContentBlock,
-                    AudioContentBlock,
-                    ResourceContentBlock,
-                    EmbeddedResourceContentBlock,
-                ],
-                Field(discriminator="type"),
-            ]
-        ],
-        Field(
-            description="The blocks of content that compose the user's message.\n\nAs a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],\nwhile other variants are optionally enabled via [`PromptCapabilities`].\n\nThe Client MUST adapt its interface according to [`PromptCapabilities`].\n\nThe client MAY include referenced pieces of context as either\n[`ContentBlock::Resource`] or [`ContentBlock::ResourceLink`].\n\nWhen available, [`ContentBlock::Resource`] is preferred\nas it avoids extra round-trips and allows the message to include\npieces of context from sources the agent may not have access to."
-        ),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The blocks of content that compose the user's message.
+
+    As a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],
+    while other variants are optionally enabled via [`PromptCapabilities`].
+
+    The Client MUST adapt its interface according to [`PromptCapabilities`].
+
+    The client MAY include referenced pieces of context as either
+    [`ContentBlock::Resource`] or [`ContentBlock::ResourceLink`].
+
+    When available, [`ContentBlock::Resource`] is preferred
+    as it avoids extra round-trips and allows the message to include
+    pieces of context from sources the agent may not have access to.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class NesSuggestContext(BaseModel):
-    recent_files: Annotated[
-        Optional[List[NesRecentFile]],
-        Field(alias="recentFiles", description="Recently accessed files."),
-    ] = None
-    related_snippets: Annotated[
-        Optional[List[NesRelatedSnippet]],
-        Field(alias="relatedSnippets", description="Related code snippets."),
-    ] = None
-    edit_history: Annotated[
-        Optional[List[NesEditHistoryEntry]],
-        Field(alias="editHistory", description="Recent edit history."),
-    ] = None
-    user_actions: Annotated[
-        Optional[List[NesUserAction]],
-        Field(
-            alias="userActions",
-            description="Recent user actions (typing, navigation, etc.).",
-        ),
-    ] = None
-    open_files: Annotated[
-        Optional[List[NesOpenFile]],
-        Field(alias="openFiles", description="Currently open files in the editor."),
-    ] = None
-    diagnostics: Annotated[
-        Optional[List[NesDiagnostic]],
-        Field(description="Current diagnostics (errors, warnings)."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    recent_files: Annotated[Optional[List[NesRecentFile]], Field(alias="recentFiles")] = None
+    """
+    Recently accessed files.
+    """
+    related_snippets: Annotated[Optional[List[NesRelatedSnippet]], Field(alias="relatedSnippets")] = None
+    """
+    Related code snippets.
+    """
+    edit_history: Annotated[Optional[List[NesEditHistoryEntry]], Field(alias="editHistory")] = None
+    """
+    Recent edit history.
+    """
+    user_actions: Annotated[Optional[List[NesUserAction]], Field(alias="userActions")] = None
+    """
+    Recent user actions (typing, navigation, etc.).
+    """
+    open_files: Annotated[Optional[List[NesOpenFile]], Field(alias="openFiles")] = None
+    """
+    Currently open files in the editor.
+    """
+    diagnostics: Optional[List[NesDiagnostic]] = None
+    """
+    Current diagnostics (errors, warnings).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class RequestPermissionResponse(BaseModel):
     outcome: Annotated[
         Union[DeniedOutcome, AllowedOutcome],
-        Field(
-            description="The user's decision on the permission request.",
-            discriminator="outcome",
-        ),
+        Field(discriminator="outcome"),
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The user's decision on the permission request.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class DidChangeDocumentNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(alias="sessionId", description="The session ID for this notification."),
-    ]
-    uri: Annotated[str, Field(description="The URI of the changed document.")]
-    version: Annotated[int, Field(description="The new version number of the document.")]
-    content_changes: Annotated[
-        List[TextDocumentContentChangeEvent],
-        Field(alias="contentChanges", description="The content changes."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this notification.
+    """
+    uri: str
+    """
+    The URI of the changed document.
+    """
+    version: int
+    """
+    The new version number of the document.
+    """
+    content_changes: Annotated[List[TextDocumentContentChangeEvent], Field(alias="contentChanges")]
+    """
+    The content changes.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("content_changes", mode="wrap")
     @classmethod
@@ -3956,8 +4557,14 @@ class ContentToolCallContent(Content):
 
 
 class ElicitationSchema(BaseModel):
-    type: Annotated[Optional[str], Field(description='Type discriminator. Always `"object"`.')] = "object"
-    title: Annotated[Optional[str], Field(description="Optional title for the schema.")] = None
+    type: Optional[str] = "object"
+    """
+    Type discriminator. Always `"object"`.
+    """
+    title: Optional[str] = None
+    """
+    Optional title for the schema.
+    """
     properties: Annotated[
         Optional[
             Dict[
@@ -3972,23 +4579,27 @@ class ElicitationSchema(BaseModel):
                 ],
             ]
         ],
-        Field(
-            description="Property definitions (must be primitive types).",
-            validate_default=True,
-        ),
+        Field(validate_default=True),
     ] = {}
-    required: Annotated[Optional[List[str]], Field(description="List of required property names.")] = None
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional description of what this schema represents."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Property definitions (must be primitive types).
+    """
+    required: Optional[List[str]] = None
+    """
+    List of required property names.
+    """
+    description: Optional[str] = None
+    """
+    Optional description of what this schema represents.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("type", mode="wrap")
     @classmethod
@@ -4002,46 +4613,45 @@ class ElicitationSchema(BaseModel):
 
 
 class ElicitationFormSessionMode(ElicitationSessionScope):
-    requested_schema: Annotated[
-        ElicitationSchema,
-        Field(
-            alias="requestedSchema",
-            description="A JSON Schema describing the form fields to present to the user.",
-        ),
-    ]
+    requested_schema: Annotated[ElicitationSchema, Field(alias="requestedSchema")]
+    """
+    A JSON Schema describing the form fields to present to the user.
+    """
 
 
 class ElicitationFormRequestMode(ElicitationRequestScope):
-    requested_schema: Annotated[
-        ElicitationSchema,
-        Field(
-            alias="requestedSchema",
-            description="A JSON Schema describing the form fields to present to the user.",
-        ),
-    ]
+    requested_schema: Annotated[ElicitationSchema, Field(alias="requestedSchema")]
+    """
+    A JSON Schema describing the form fields to present to the user.
+    """
 
 
 class ElicitationFormMode(RootModel[Union[ElicitationFormSessionMode, ElicitationFormRequestMode]]):
-    root: Annotated[
-        Union[ElicitationFormSessionMode, ElicitationFormRequestMode],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation mode where the client renders a form from the provided schema."
-        ),
-    ]
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    root: Union[ElicitationFormSessionMode, ElicitationFormRequestMode]
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Form-based elicitation mode where the client renders a form from the provided schema.
+    """
 
 
 class NesEventCapabilities(BaseModel):
-    document: Annotated[
-        Optional[NesDocumentEventCapabilities],
-        Field(description="Document event capabilities."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    document: Optional[NesDocumentEventCapabilities] = None
+    """
+    Document event capabilities.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("document", mode="wrap")
     @classmethod
@@ -4050,31 +4660,38 @@ class NesEventCapabilities(BaseModel):
 
 
 class SessionConfigOptionSelect(SessionConfigSelect):
-    id: Annotated[str, Field(description="Unique identifier for the configuration option.")]
-    name: Annotated[str, Field(description="Human-readable label for the option.")]
-    description: Annotated[
-        Optional[str],
-        Field(description="Optional description for the Client to display to the user."),
+    id: str
+    """
+    Unique identifier for the configuration option.
+    """
+    name: str
+    """
+    Human-readable label for the option.
+    """
+    description: Optional[str] = None
+    """
+    Optional description for the Client to display to the user.
+    """
+    category: Optional[
+        Union[
+            Literal["mode"],
+            Literal["model"],
+            Literal["model_config"],
+            Literal["thought_level"],
+            Dict[str, Any],
+        ]
     ] = None
-    category: Annotated[
-        Optional[
-            Union[
-                Literal["mode"],
-                Literal["model"],
-                Literal["model_config"],
-                Literal["thought_level"],
-                Dict[str, Any],
-            ]
-        ],
-        Field(description="Optional semantic category for this option (UX only)."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Optional semantic category for this option (UX only).
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     type: Literal["select"]
 
     @field_validator("category", "description", mode="wrap")
@@ -4084,12 +4701,12 @@ class SessionConfigOptionSelect(SessionConfigSelect):
 
 
 class LoadSessionResponse(BaseModel):
-    modes: Annotated[
-        Optional[SessionModeState],
-        Field(
-            description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
-        ),
-    ] = None
+    modes: Optional[SessionModeState] = None
+    """
+    Initial mode state if supported by the Agent
+
+    See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
+    """
     config_options: Annotated[
         Optional[
             List[
@@ -4099,18 +4716,19 @@ class LoadSessionResponse(BaseModel):
                 ]
             ]
         ],
-        Field(
-            alias="configOptions",
-            description="Initial session configuration options if supported by the Agent.",
-        ),
+        Field(alias="configOptions"),
     ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Initial session configuration options if supported by the Agent.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("modes", mode="wrap")
     @classmethod
@@ -4124,19 +4742,16 @@ class LoadSessionResponse(BaseModel):
 
 
 class ForkSessionResponse(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="Unique identifier for the newly created forked session.",
-        ),
-    ]
-    modes: Annotated[
-        Optional[SessionModeState],
-        Field(
-            description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    Unique identifier for the newly created forked session.
+    """
+    modes: Optional[SessionModeState] = None
+    """
+    Initial mode state if supported by the Agent
+
+    See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
+    """
     config_options: Annotated[
         Optional[
             List[
@@ -4146,18 +4761,19 @@ class ForkSessionResponse(BaseModel):
                 ]
             ]
         ],
-        Field(
-            alias="configOptions",
-            description="Initial session configuration options if supported by the Agent.",
-        ),
+        Field(alias="configOptions"),
     ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Initial session configuration options if supported by the Agent.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("modes", mode="wrap")
     @classmethod
@@ -4171,12 +4787,12 @@ class ForkSessionResponse(BaseModel):
 
 
 class ResumeSessionResponse(BaseModel):
-    modes: Annotated[
-        Optional[SessionModeState],
-        Field(
-            description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
-        ),
-    ] = None
+    modes: Optional[SessionModeState] = None
+    """
+    Initial mode state if supported by the Agent
+
+    See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
+    """
     config_options: Annotated[
         Optional[
             List[
@@ -4186,18 +4802,19 @@ class ResumeSessionResponse(BaseModel):
                 ]
             ]
         ],
-        Field(
-            alias="configOptions",
-            description="Initial session configuration options if supported by the Agent.",
-        ),
+        Field(alias="configOptions"),
     ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Initial session configuration options if supported by the Agent.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("modes", mode="wrap")
     @classmethod
@@ -4218,18 +4835,19 @@ class SetSessionConfigOptionResponse(BaseModel):
                 Field(discriminator="type"),
             ]
         ],
-        Field(
-            alias="configOptions",
-            description="The full set of configuration options and their current values.",
-        ),
+        Field(alias="configOptions"),
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The full set of configuration options and their current values.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("config_options", mode="wrap")
     @classmethod
@@ -4262,54 +4880,55 @@ class AvailableCommandsUpdate(_AvailableCommandsUpdate):
 
 
 class ToolCall(BaseModel):
-    tool_call_id: Annotated[
-        str,
-        Field(
-            alias="toolCallId",
-            description="Unique identifier for this tool call within the session.",
-        ),
-    ]
-    title: Annotated[
-        str,
-        Field(description="Human-readable title describing what the tool is doing."),
-    ]
-    kind: Annotated[
-        Optional[ToolKind],
-        Field(
-            description="The category of tool being invoked.\nHelps clients choose appropriate icons and UI treatment."
-        ),
-    ] = None
-    status: Annotated[Optional[ToolCallStatus], Field(description="Current execution status of the tool call.")] = None
-    content: Annotated[
-        Optional[
-            List[
-                Annotated[
-                    Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent],
-                    Field(discriminator="type"),
-                ]
+    tool_call_id: Annotated[str, Field(alias="toolCallId")]
+    """
+    Unique identifier for this tool call within the session.
+    """
+    title: str
+    """
+    Human-readable title describing what the tool is doing.
+    """
+    kind: Optional[ToolKind] = None
+    """
+    The category of tool being invoked.
+    Helps clients choose appropriate icons and UI treatment.
+    """
+    status: Optional[ToolCallStatus] = None
+    """
+    Current execution status of the tool call.
+    """
+    content: Optional[
+        List[
+            Annotated[
+                Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent],
+                Field(discriminator="type"),
             ]
-        ],
-        Field(description="Content produced by the tool call."),
+        ]
     ] = None
-    locations: Annotated[
-        Optional[List[ToolCallLocation]],
-        Field(description='File locations affected by this tool call.\nEnables "follow-along" features in clients.'),
-    ] = None
-    raw_input: Annotated[
-        Optional[Any],
-        Field(alias="rawInput", description="Raw input parameters sent to the tool."),
-    ] = None
-    raw_output: Annotated[
-        Optional[Any],
-        Field(alias="rawOutput", description="Raw output returned by the tool."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Content produced by the tool call.
+    """
+    locations: Optional[List[ToolCallLocation]] = None
+    """
+    File locations affected by this tool call.
+    Enables "follow-along" features in clients.
+    """
+    raw_input: Annotated[Optional[Any], Field(alias="rawInput")] = None
+    """
+    Raw input parameters sent to the tool.
+    """
+    raw_output: Annotated[Optional[Any], Field(alias="rawOutput")] = None
+    """
+    Raw output returned by the tool.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("kind", "raw_input", "raw_output", "status", mode="wrap")
     @classmethod
@@ -4335,18 +4954,19 @@ class _ConfigOptionUpdate(BaseModel):
                 Field(discriminator="type"),
             ]
         ],
-        Field(
-            alias="configOptions",
-            description="The full set of configuration options and their current values.",
-        ),
+        Field(alias="configOptions"),
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The full set of configuration options and their current values.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("config_options", mode="wrap")
     @classmethod
@@ -4355,62 +4975,82 @@ class _ConfigOptionUpdate(BaseModel):
 
 
 class ClientCapabilities(BaseModel):
-    fs: Annotated[
-        Optional[FileSystemCapabilities],
-        Field(
-            description="File system capabilities supported by the client.\nDetermines which file operations the agent can request.",
-            validate_default=True,
-        ),
-    ] = FileSystemCapabilities()
-    terminal: Annotated[
-        Optional[bool],
-        Field(description="Whether the Client support all `terminal/*` methods."),
-    ] = False
-    session: Annotated[
-        Optional[ClientSessionCapabilities],
-        Field(
-            description="Session-related capabilities supported by the client.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nsession-related extensions."
-        ),
-    ] = None
-    plan: Annotated[
-        Optional[PlanCapabilities],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the client supports `plan_update` and `plan_removed` session updates.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client can receive both update types."
-        ),
-    ] = None
-    auth: Annotated[
-        Optional[AuthCapabilities],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`.",
-            validate_default=True,
-        ),
-    ] = {"terminal": False}
-    elicitation: Annotated[
-        Optional[ElicitationCapabilities],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.\n\nOptional. Omitted or `null` both mean the client does not advertise\nelicitation support."
-        ),
-    ] = None
-    nes: Annotated[
-        Optional[ClientNesCapabilities],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nNES suggestion-kind extensions."
-        ),
-    ] = None
-    position_encodings: Annotated[
-        Optional[List[str]],
-        Field(
-            alias="positionEncodings",
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encodings supported by the client, in order of preference.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    fs: Annotated[Optional[FileSystemCapabilities], Field(validate_default=True)] = FileSystemCapabilities()
+    """
+    File system capabilities supported by the client.
+    Determines which file operations the agent can request.
+    """
+    terminal: Optional[bool] = False
+    """
+    Whether the Client support all `terminal/*` methods.
+    """
+    session: Optional[ClientSessionCapabilities] = None
+    """
+    Session-related capabilities supported by the client.
+
+    Optional. Omitted or `null` both mean the client does not advertise any
+    session-related extensions.
+    """
+    plan: Optional[PlanCapabilities] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Whether the client supports `plan_update` and `plan_removed` session updates.
+
+    Optional. Omitted or `null` both mean the client does not advertise support.
+    Supplying `{}` means the client can receive both update types.
+    """
+    auth: Annotated[Optional[AuthCapabilities], Field(validate_default=True)] = {"terminal": False}
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Authentication capabilities supported by the client.
+    Determines which authentication method types the agent may include
+    in its `InitializeResponse`.
+    """
+    elicitation: Optional[ElicitationCapabilities] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Elicitation capabilities supported by the client.
+    Determines which elicitation modes the agent may use.
+
+    Optional. Omitted or `null` both mean the client does not advertise
+    elicitation support.
+    """
+    nes: Optional[ClientNesCapabilities] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    NES (Next Edit Suggestions) capabilities supported by the client.
+
+    Optional. Omitted or `null` both mean the client does not advertise any
+    NES suggestion-kind extensions.
+    """
+    position_encodings: Annotated[Optional[List[str]], Field(alias="positionEncodings")] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    The position encodings supported by the client, in order of preference.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("terminal", mode="wrap")
     @classmethod
@@ -4439,117 +5079,154 @@ class ClientCapabilities(BaseModel):
 
 
 class SuggestNesRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    uri: Annotated[str, Field(description="The URI of the document to suggest for.")]
-    version: Annotated[int, Field(description="The version number of the document.")]
-    position: Annotated[Position, Field(description="The current cursor position.")]
-    selection: Annotated[Optional[Range], Field(description="The current text selection range, if any.")] = None
-    trigger_kind: Annotated[
-        str,
-        Field(alias="triggerKind", description="What triggered this suggestion request."),
-    ]
-    context: Annotated[
-        Optional[NesSuggestContext],
-        Field(description="Context for the suggestion, included based on agent capabilities."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    uri: str
+    """
+    The URI of the document to suggest for.
+    """
+    version: int
+    """
+    The version number of the document.
+    """
+    position: Position
+    """
+    The current cursor position.
+    """
+    selection: Optional[Range] = None
+    """
+    The current text selection range, if any.
+    """
+    trigger_kind: Annotated[str, Field(alias="triggerKind")]
+    """
+    What triggered this suggestion request.
+    """
+    context: Optional[NesSuggestContext] = None
+    """
+    Context for the suggestion, included based on agent capabilities.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ClientResponseMessage(BaseModel):
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(description="The id of the request this response answers."),
-    ]
-    result: Annotated[
+    id: Optional[Union[int, str]]
+    """
+    The id of the request this response answers.
+    """
+    result: Union[
+        WriteTextFileResponse,
+        ReadTextFileResponse,
+        RequestPermissionResponse,
+        CreateTerminalResponse,
+        TerminalOutputResponse,
+        ReleaseTerminalResponse,
+        WaitForTerminalExitResponse,
+        KillTerminalResponse,
+        ConnectMcpResponse,
+        DisconnectMcpResponse,
         Union[
-            WriteTextFileResponse,
-            ReadTextFileResponse,
-            RequestPermissionResponse,
-            CreateTerminalResponse,
-            TerminalOutputResponse,
-            ReleaseTerminalResponse,
-            WaitForTerminalExitResponse,
-            KillTerminalResponse,
-            ConnectMcpResponse,
-            DisconnectMcpResponse,
-            Union[
-                AcceptElicitationResponse,
-                DeclineElicitationResponse,
-                CancelElicitationResponse,
-                OtherElicitationResponse,
-            ],
-            Any,
+            AcceptElicitationResponse,
+            DeclineElicitationResponse,
+            CancelElicitationResponse,
+            OtherElicitationResponse,
         ],
-        Field(description="Method-specific response data."),
+        Any,
     ]
+    """
+    Method-specific response data.
+    """
 
 
 class ClientResponse(RootModel[Union[ClientResponseMessage, ClientErrorMessage]]):
-    root: Annotated[
-        Union[ClientResponseMessage, ClientErrorMessage],
-        Field(description="A JSON-RPC response object."),
-    ]
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    root: Union[ClientResponseMessage, ClientErrorMessage]
+    """
+    A JSON-RPC response object.
+    """
 
 
 class ClientNotification(BaseModel):
-    method: Annotated[str, Field(description="The notification method name.")]
-    params: Annotated[
-        Optional[
-            Union[
-                CancelNotification,
-                DidOpenDocumentNotification,
-                DidChangeDocumentNotification,
-                DidCloseDocumentNotification,
-                DidSaveDocumentNotification,
-                DidFocusDocumentNotification,
-                AcceptNesNotification,
-                RejectNesNotification,
-                MessageMcpNotification,
-                Any,
-            ]
-        ],
-        Field(description="Method-specific notification parameters."),
+    method: str
+    """
+    The notification method name.
+    """
+    params: Optional[
+        Union[
+            CancelNotification,
+            DidOpenDocumentNotification,
+            DidChangeDocumentNotification,
+            DidCloseDocumentNotification,
+            DidSaveDocumentNotification,
+            DidFocusDocumentNotification,
+            AcceptNesNotification,
+            RejectNesNotification,
+            MessageMcpNotification,
+            Any,
+        ]
     ] = None
+    """
+    Method-specific notification parameters.
+    """
 
 
 class ToolCallUpdate(BaseModel):
-    tool_call_id: Annotated[
-        str,
-        Field(alias="toolCallId", description="The ID of the tool call being updated."),
-    ]
-    kind: Annotated[Optional[ToolKind], Field(description="Update the tool kind.")] = None
-    status: Annotated[Optional[ToolCallStatus], Field(description="Update the execution status.")] = None
-    title: Annotated[Optional[str], Field(description="Update the human-readable title.")] = None
-    content: Annotated[
-        Optional[
-            List[
-                Annotated[
-                    Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent],
-                    Field(discriminator="type"),
-                ]
+    tool_call_id: Annotated[str, Field(alias="toolCallId")]
+    """
+    The ID of the tool call being updated.
+    """
+    kind: Optional[ToolKind] = None
+    """
+    Update the tool kind.
+    """
+    status: Optional[ToolCallStatus] = None
+    """
+    Update the execution status.
+    """
+    title: Optional[str] = None
+    """
+    Update the human-readable title.
+    """
+    content: Optional[
+        List[
+            Annotated[
+                Union[ContentToolCallContent, FileEditToolCallContent, TerminalToolCallContent],
+                Field(discriminator="type"),
             ]
-        ],
-        Field(description="Replace the content collection."),
+        ]
     ] = None
-    locations: Annotated[
-        Optional[List[ToolCallLocation]],
-        Field(description="Replace the locations collection."),
-    ] = None
-    raw_input: Annotated[Optional[Any], Field(alias="rawInput", description="Update the raw input.")] = None
-    raw_output: Annotated[Optional[Any], Field(alias="rawOutput", description="Update the raw output.")] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Replace the content collection.
+    """
+    locations: Optional[List[ToolCallLocation]] = None
+    """
+    Replace the locations collection.
+    """
+    raw_input: Annotated[Optional[Any], Field(alias="rawInput")] = None
+    """
+    Update the raw input.
+    """
+    raw_output: Annotated[Optional[Any], Field(alias="rawOutput")] = None
+    """
+    Update the raw output.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("kind", "raw_input", "raw_output", "status", "title", mode="wrap")
     @classmethod
@@ -4568,47 +5245,43 @@ class ToolCallUpdate(BaseModel):
 
 
 class CreateFormSessionElicitationRequest(ElicitationSessionScope):
-    message: Annotated[
-        str,
-        Field(description="A human-readable message describing what input is needed."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    message: str
+    """
+    A human-readable message describing what input is needed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     mode: Literal["form"]
-    requested_schema: Annotated[
-        ElicitationSchema,
-        Field(
-            alias="requestedSchema",
-            description="A JSON Schema describing the form fields to present to the user.",
-        ),
-    ]
+    requested_schema: Annotated[ElicitationSchema, Field(alias="requestedSchema")]
+    """
+    A JSON Schema describing the form fields to present to the user.
+    """
 
 
 class CreateFormRequestElicitationRequest(ElicitationRequestScope):
-    message: Annotated[
-        str,
-        Field(description="A human-readable message describing what input is needed."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    message: str
+    """
+    A human-readable message describing what input is needed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
     mode: Literal["form"]
-    requested_schema: Annotated[
-        ElicitationSchema,
-        Field(
-            alias="requestedSchema",
-            description="A JSON Schema describing the form fields to present to the user.",
-        ),
-    ]
+    requested_schema: Annotated[ElicitationSchema, Field(alias="requestedSchema")]
+    """
+    A JSON Schema describing the form fields to present to the user.
+    """
 
 
 ElicitationMode = Union[
@@ -4639,21 +5312,22 @@ CreateElicitationResponse = Union[
 
 
 class NesCapabilities(BaseModel):
-    events: Annotated[
-        Optional[NesEventCapabilities],
-        Field(description="Events the agent wants to receive."),
-    ] = None
-    context: Annotated[
-        Optional[NesContextCapabilities],
-        Field(description="Context the agent wants attached to each suggestion request."),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    events: Optional[NesEventCapabilities] = None
+    """
+    Events the agent wants to receive.
+    """
+    context: Optional[NesContextCapabilities] = None
+    """
+    Context the agent wants attached to each suggestion request.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("context", "events", mode="wrap")
     @classmethod
@@ -4662,19 +5336,18 @@ class NesCapabilities(BaseModel):
 
 
 class NewSessionResponse(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="Unique identifier for the created session.\n\nUsed in all subsequent requests for this conversation.",
-        ),
-    ]
-    modes: Annotated[
-        Optional[SessionModeState],
-        Field(
-            description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    Unique identifier for the created session.
+
+    Used in all subsequent requests for this conversation.
+    """
+    modes: Optional[SessionModeState] = None
+    """
+    Initial mode state if supported by the Agent
+
+    See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
+    """
     config_options: Annotated[
         Optional[
             List[
@@ -4684,18 +5357,19 @@ class NewSessionResponse(BaseModel):
                 ]
             ]
         ],
-        Field(
-            alias="configOptions",
-            description="Initial session configuration options if supported by the Agent.",
-        ),
+        Field(alias="configOptions"),
     ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Initial session configuration options if supported by the Agent.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("modes", mode="wrap")
     @classmethod
@@ -4709,27 +5383,28 @@ class NewSessionResponse(BaseModel):
 
 
 class SuggestNesResponse(BaseModel):
-    suggestions: Annotated[
-        List[
-            Annotated[
-                Union[
-                    NesEditSuggestionVariant,
-                    NesJumpSuggestionVariant,
-                    NesRenameSuggestionVariant,
-                    NesSearchAndReplaceSuggestionVariant,
-                ],
-                Field(discriminator="kind"),
-            ]
-        ],
-        Field(description="The list of suggestions."),
+    suggestions: List[
+        Annotated[
+            Union[
+                NesEditSuggestionVariant,
+                NesJumpSuggestionVariant,
+                NesRenameSuggestionVariant,
+                NesSearchAndReplaceSuggestionVariant,
+            ],
+            Field(discriminator="kind"),
+        ]
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The list of suggestions.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ToolCallStart(ToolCall):
@@ -4745,37 +5420,31 @@ class ConfigOptionUpdate(_ConfigOptionUpdate):
 
 
 class InitializeRequest(BaseModel):
-    protocol_version: Annotated[
-        int,
-        Field(
-            alias="protocolVersion",
-            description="The latest protocol version supported by the client.",
-            ge=0,
-            le=65535,
-        ),
-    ]
+    protocol_version: Annotated[int, Field(alias="protocolVersion", ge=0, le=65535)]
+    """
+    The latest protocol version supported by the client.
+    """
     client_capabilities: Annotated[
         Optional[ClientCapabilities],
-        Field(
-            alias="clientCapabilities",
-            description="Capabilities supported by the client.",
-            validate_default=True,
-        ),
+        Field(alias="clientCapabilities", validate_default=True),
     ] = ClientCapabilities()
-    client_info: Annotated[
-        Optional[Implementation],
-        Field(
-            alias="clientInfo",
-            description="Information about the Client name and version sent to the Agent.\n\nNote: in future versions of the protocol, this will be required.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Capabilities supported by the client.
+    """
+    client_info: Annotated[Optional[Implementation], Field(alias="clientInfo")] = None
+    """
+    Information about the Client name and version sent to the Agent.
+
+    Note: in future versions of the protocol, this will be required.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("protocol_version", mode="before")
     @classmethod
@@ -4811,92 +5480,95 @@ class InitializeRequest(BaseModel):
 
 
 class RequestPermissionRequest(BaseModel):
-    session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    tool_call: Annotated[
-        ToolCallUpdate,
-        Field(
-            alias="toolCall",
-            description="Details about the tool call requiring permission.",
-        ),
-    ]
-    options: Annotated[
-        List[PermissionOption],
-        Field(description="Available permission options for the user to choose from."),
-    ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The session ID for this request.
+    """
+    tool_call: Annotated[ToolCallUpdate, Field(alias="toolCall")]
+    """
+    Details about the tool call requiring permission.
+    """
+    options: List[PermissionOption]
+    """
+    Available permission options for the user to choose from.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class AgentCapabilities(BaseModel):
-    load_session: Annotated[
-        Optional[bool],
-        Field(
-            alias="loadSession",
-            description="Whether the agent supports `session/load`.",
-        ),
-    ] = False
+    load_session: Annotated[Optional[bool], Field(alias="loadSession")] = False
+    """
+    Whether the agent supports `session/load`.
+    """
     prompt_capabilities: Annotated[
         Optional[PromptCapabilities],
-        Field(
-            alias="promptCapabilities",
-            description="Prompt capabilities supported by the agent.",
-            validate_default=True,
-        ),
+        Field(alias="promptCapabilities", validate_default=True),
     ] = PromptCapabilities()
-    mcp_capabilities: Annotated[
-        Optional[McpCapabilities],
-        Field(
-            alias="mcpCapabilities",
-            description="MCP capabilities supported by the agent.",
-            validate_default=True,
-        ),
-    ] = McpCapabilities()
+    """
+    Prompt capabilities supported by the agent.
+    """
+    mcp_capabilities: Annotated[Optional[McpCapabilities], Field(alias="mcpCapabilities", validate_default=True)] = (
+        McpCapabilities()
+    )
+    """
+    MCP capabilities supported by the agent.
+    """
     session_capabilities: Annotated[
         Optional[SessionCapabilities],
-        Field(
-            alias="sessionCapabilities",
-            description="Session lifecycle and prompt capabilities advertised by the agent.",
-            validate_default=True,
-        ),
+        Field(alias="sessionCapabilities", validate_default=True),
     ] = SessionCapabilities()
-    auth: Annotated[
-        Optional[AgentAuthCapabilities],
-        Field(
-            description="Authentication-related capabilities supported by the agent.",
-            validate_default=True,
-        ),
-    ] = {}
-    providers: Annotated[
-        Optional[ProvidersCapabilities],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports provider configuration methods."
-        ),
-    ] = None
-    nes: Annotated[
-        Optional[NesCapabilities],
-        Field(
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support\nfor NES methods."
-        ),
-    ] = None
-    position_encoding: Annotated[
-        Optional[str],
-        Field(
-            alias="positionEncoding",
-            description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encoding selected by the agent from the client's supported encodings.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Session lifecycle and prompt capabilities advertised by the agent.
+    """
+    auth: Annotated[Optional[AgentAuthCapabilities], Field(validate_default=True)] = {}
+    """
+    Authentication-related capabilities supported by the agent.
+    """
+    providers: Optional[ProvidersCapabilities] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Provider configuration capabilities supported by the agent.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support.
+    Supplying `{}` means the agent supports provider configuration methods.
+    """
+    nes: Optional[NesCapabilities] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    NES (Next Edit Suggestions) capabilities supported by the agent.
+
+    Optional. Omitted or `null` both mean the agent does not advertise support
+    for NES methods.
+    """
+    position_encoding: Annotated[Optional[str], Field(alias="positionEncoding")] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    The position encoding selected by the agent from the client's supported encodings.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("load_session", mode="wrap")
     @classmethod
@@ -4925,13 +5597,10 @@ class AgentCapabilities(BaseModel):
 
 
 class SessionNotification(BaseModel):
-    session_id: Annotated[
-        str,
-        Field(
-            alias="sessionId",
-            description="The ID of the session this update pertains to.",
-        ),
-    ]
+    session_id: Annotated[str, Field(alias="sessionId")]
+    """
+    The ID of the session this update pertains to.
+    """
     update: Annotated[
         Union[
             UserMessageChunk,
@@ -4948,127 +5617,133 @@ class SessionNotification(BaseModel):
             SessionInfoUpdate,
             UsageUpdate,
         ],
-        Field(description="The actual update content.", discriminator="session_update"),
+        Field(discriminator="session_update"),
     ]
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    The actual update content.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
 
 class ClientRequest(BaseModel):
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(description="The request id used to correlate the matching response."),
-    ]
-    method: Annotated[str, Field(description="The method name to invoke.")]
-    params: Annotated[
-        Optional[
-            Union[
-                InitializeRequest,
-                AuthenticateRequest,
-                ListProvidersRequest,
-                SetProviderRequest,
-                DisableProviderRequest,
-                LogoutRequest,
-                NewSessionRequest,
-                LoadSessionRequest,
-                ListSessionsRequest,
-                DeleteSessionRequest,
-                ForkSessionRequest,
-                ResumeSessionRequest,
-                CloseSessionRequest,
-                SetSessionModeRequest,
-                PromptRequest,
-                StartNesRequest,
-                SuggestNesRequest,
-                CloseNesRequest,
-                MessageMcpRequest,
-                Union[SetSessionConfigOptionBooleanRequest, SetSessionConfigOptionSelectRequest],
-                Any,
-            ]
-        ],
-        Field(description="Method-specific request parameters."),
-    ]
+    id: Optional[Union[int, str]]
+    """
+    The request id used to correlate the matching response.
+    """
+    method: str
+    """
+    The method name to invoke.
+    """
+    params: Optional[
+        Union[
+            InitializeRequest,
+            AuthenticateRequest,
+            ListProvidersRequest,
+            SetProviderRequest,
+            DisableProviderRequest,
+            LogoutRequest,
+            NewSessionRequest,
+            LoadSessionRequest,
+            ListSessionsRequest,
+            DeleteSessionRequest,
+            ForkSessionRequest,
+            ResumeSessionRequest,
+            CloseSessionRequest,
+            SetSessionModeRequest,
+            PromptRequest,
+            StartNesRequest,
+            SuggestNesRequest,
+            CloseNesRequest,
+            MessageMcpRequest,
+            Union[SetSessionConfigOptionBooleanRequest, SetSessionConfigOptionSelectRequest],
+            Any,
+        ]
+    ] = None
+    """
+    Method-specific request parameters.
+    """
 
 
 class AgentRequest(BaseModel):
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(description="The request id used to correlate the matching response."),
-    ]
-    method: Annotated[str, Field(description="The method name to invoke.")]
-    params: Annotated[
-        Optional[
+    id: Optional[Union[int, str]]
+    """
+    The request id used to correlate the matching response.
+    """
+    method: str
+    """
+    The method name to invoke.
+    """
+    params: Optional[
+        Union[
+            WriteTextFileRequest,
+            ReadTextFileRequest,
+            RequestPermissionRequest,
+            CreateTerminalRequest,
+            TerminalOutputRequest,
+            ReleaseTerminalRequest,
+            WaitForTerminalExitRequest,
+            KillTerminalRequest,
+            ConnectMcpRequest,
+            MessageMcpRequest,
+            DisconnectMcpRequest,
             Union[
-                WriteTextFileRequest,
-                ReadTextFileRequest,
-                RequestPermissionRequest,
-                CreateTerminalRequest,
-                TerminalOutputRequest,
-                ReleaseTerminalRequest,
-                WaitForTerminalExitRequest,
-                KillTerminalRequest,
-                ConnectMcpRequest,
-                MessageMcpRequest,
-                DisconnectMcpRequest,
-                Union[
-                    CreateFormSessionElicitationRequest,
-                    CreateFormRequestElicitationRequest,
-                    CreateUrlSessionElicitationRequest,
-                    CreateUrlRequestElicitationRequest,
-                    CreateOtherElicitationRequest,
-                ],
-                Any,
-            ]
-        ],
-        Field(description="Method-specific request parameters."),
-    ]
+                CreateFormSessionElicitationRequest,
+                CreateFormRequestElicitationRequest,
+                CreateUrlSessionElicitationRequest,
+                CreateUrlRequestElicitationRequest,
+                CreateOtherElicitationRequest,
+            ],
+            Any,
+        ]
+    ] = None
+    """
+    Method-specific request parameters.
+    """
 
 
 class InitializeResponse(BaseModel):
-    protocol_version: Annotated[
-        int,
-        Field(
-            alias="protocolVersion",
-            description="The protocol version the client specified if supported by the agent,\nor the latest protocol version supported by the agent.\n\nThe client should disconnect, if it doesn't support this version.",
-            ge=0,
-            le=65535,
-        ),
-    ]
+    protocol_version: Annotated[int, Field(alias="protocolVersion", ge=0, le=65535)]
+    """
+    The protocol version the client specified if supported by the agent,
+    or the latest protocol version supported by the agent.
+
+    The client should disconnect, if it doesn't support this version.
+    """
     agent_capabilities: Annotated[
         Optional[AgentCapabilities],
-        Field(
-            alias="agentCapabilities",
-            description="Capabilities supported by the agent.",
-            validate_default=True,
-        ),
+        Field(alias="agentCapabilities", validate_default=True),
     ] = AgentCapabilities()
+    """
+    Capabilities supported by the agent.
+    """
     auth_methods: Annotated[
         Optional[List[Union[EnvVarAuthMethod, TerminalAuthMethod, AuthMethodAgent]]],
-        Field(
-            alias="authMethods",
-            description="Authentication methods supported by the agent.",
-            validate_default=True,
-        ),
+        Field(alias="authMethods", validate_default=True),
     ] = []
-    agent_info: Annotated[
-        Optional[Implementation],
-        Field(
-            alias="agentInfo",
-            description="Information about the Agent name and version sent to the Client.\n\nNote: in future versions of the protocol, this will be required.",
-        ),
-    ] = None
-    field_meta: Annotated[
-        Optional[Dict[str, Any]],
-        Field(
-            alias="_meta",
-            description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-        ),
-    ] = None
+    """
+    Authentication methods supported by the agent.
+    """
+    agent_info: Annotated[Optional[Implementation], Field(alias="agentInfo")] = None
+    """
+    Information about the Agent name and version sent to the Client.
+
+    Note: in future versions of the protocol, this will be required.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    The _meta property is reserved by ACP to allow clients and agents to attach additional
+    metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    these keys.
+
+    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    """
 
     @field_validator("agent_info", mode="wrap")
     @classmethod
@@ -5097,54 +5772,59 @@ class InitializeResponse(BaseModel):
 
 
 class AgentNotification(BaseModel):
-    method: Annotated[str, Field(description="The notification method name.")]
-    params: Annotated[
-        Optional[
-            Union[
-                SessionNotification,
-                CompleteElicitationNotification,
-                MessageMcpNotification,
-                Any,
-            ]
-        ],
-        Field(description="Method-specific notification parameters."),
+    method: str
+    """
+    The notification method name.
+    """
+    params: Optional[
+        Union[
+            SessionNotification,
+            CompleteElicitationNotification,
+            MessageMcpNotification,
+            Any,
+        ]
     ] = None
+    """
+    Method-specific notification parameters.
+    """
 
 
 class AgentResponseMessage(BaseModel):
-    id: Annotated[
-        Optional[Union[int, str]],
-        Field(description="The id of the request this response answers."),
+    id: Optional[Union[int, str]]
+    """
+    The id of the request this response answers.
+    """
+    result: Union[
+        InitializeResponse,
+        AuthenticateResponse,
+        ListProvidersResponse,
+        SetProviderResponse,
+        DisableProviderResponse,
+        LogoutResponse,
+        NewSessionResponse,
+        LoadSessionResponse,
+        ListSessionsResponse,
+        DeleteSessionResponse,
+        ForkSessionResponse,
+        ResumeSessionResponse,
+        CloseSessionResponse,
+        SetSessionModeResponse,
+        SetSessionConfigOptionResponse,
+        PromptResponse,
+        StartNesResponse,
+        SuggestNesResponse,
+        CloseNesResponse,
+        Any,
     ]
-    result: Annotated[
-        Union[
-            InitializeResponse,
-            AuthenticateResponse,
-            ListProvidersResponse,
-            SetProviderResponse,
-            DisableProviderResponse,
-            LogoutResponse,
-            NewSessionResponse,
-            LoadSessionResponse,
-            ListSessionsResponse,
-            DeleteSessionResponse,
-            ForkSessionResponse,
-            ResumeSessionResponse,
-            CloseSessionResponse,
-            SetSessionModeResponse,
-            SetSessionConfigOptionResponse,
-            PromptResponse,
-            StartNesResponse,
-            SuggestNesResponse,
-            CloseNesResponse,
-            Any,
-        ],
-        Field(description="Method-specific response data."),
-    ]
+    """
+    Method-specific response data.
+    """
 
 
 class AgentResponse(RootModel[Union[AgentResponseMessage, AgentErrorMessage]]):
-    root: Annotated[
-        Union[AgentResponseMessage, AgentErrorMessage],
-        Field(description="A JSON-RPC response object."),
-    ]
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    root: Union[AgentResponseMessage, AgentErrorMessage]
+    """
+    A JSON-RPC response object.
+    """

--- a/src/acp/schema.py
+++ b/src/acp/schema.py
@@ -37,22 +37,13 @@ class Jsonrpc(Enum):
 
 
 class ReadTextFileRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # Absolute path to the file to read.
     path: Annotated[str, Field(description="Absolute path to the file to read.")]
-    # Line number to start reading from (1-based).
     line: Annotated[
         Optional[int],
         Field(description="Line number to start reading from (1-based).", ge=0),
     ] = None
-    # Maximum number of lines to read.
     limit: Annotated[Optional[int], Field(description="Maximum number of lines to read.", ge=0)] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -68,7 +59,6 @@ class ReadTextFileRequest(BaseModel):
 
 
 class TextResourceContents(BaseModel):
-    # MIME type describing the encoded media payload.
     mime_type: Annotated[
         Optional[str],
         Field(
@@ -76,15 +66,8 @@ class TextResourceContents(BaseModel):
             description="MIME type describing the encoded media payload.",
         ),
     ] = None
-    # Text payload carried by this content block.
     text: Annotated[str, Field(description="Text payload carried by this content block.")]
-    # URI associated with this resource or media payload.
     uri: Annotated[str, Field(description="URI associated with this resource or media payload.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -100,9 +83,7 @@ class TextResourceContents(BaseModel):
 
 
 class BlobResourceContents(BaseModel):
-    # Base64-encoded bytes for a binary resource payload.
     blob: Annotated[str, Field(description="Base64-encoded bytes for a binary resource payload.")]
-    # MIME type describing the encoded media payload.
     mime_type: Annotated[
         Optional[str],
         Field(
@@ -110,13 +91,7 @@ class BlobResourceContents(BaseModel):
             description="MIME type describing the encoded media payload.",
         ),
     ] = None
-    # URI associated with this resource or media payload.
     uri: Annotated[str, Field(description="URI associated with this resource or media payload.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -132,20 +107,12 @@ class BlobResourceContents(BaseModel):
 
 
 class Diff(BaseModel):
-    # The absolute file path being modified.
     path: Annotated[str, Field(description="The absolute file path being modified.")]
-    # The original content (None for new files).
     old_text: Annotated[
         Optional[str],
         Field(alias="oldText", description="The original content (None for new files)."),
     ] = None
-    # The new content after modification.
     new_text: Annotated[str, Field(alias="newText", description="The new content after modification.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -161,7 +128,6 @@ class Diff(BaseModel):
 
 
 class Terminal(BaseModel):
-    # Identifier of the terminal instance to embed in the content stream.
     terminal_id: Annotated[
         str,
         Field(
@@ -169,11 +135,6 @@ class Terminal(BaseModel):
             description="Identifier of the terminal instance to embed in the content stream.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -184,15 +145,8 @@ class Terminal(BaseModel):
 
 
 class ToolCallLocation(BaseModel):
-    # The absolute file path being accessed or modified.
     path: Annotated[str, Field(description="The absolute file path being accessed or modified.")]
-    # Optional line number within the file.
     line: Annotated[Optional[int], Field(description="Optional line number within the file.", ge=0)] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -208,15 +162,8 @@ class ToolCallLocation(BaseModel):
 
 
 class EnvVariable(BaseModel):
-    # The name of the environment variable.
     name: Annotated[str, Field(description="The name of the environment variable.")]
-    # The value to set for the environment variable.
     value: Annotated[str, Field(description="The value to set for the environment variable.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -227,18 +174,11 @@ class EnvVariable(BaseModel):
 
 
 class TerminalOutputRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # The ID of the terminal to get output from.
     terminal_id: Annotated[
         str,
         Field(alias="terminalId", description="The ID of the terminal to get output from."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -249,15 +189,8 @@ class TerminalOutputRequest(BaseModel):
 
 
 class ReleaseTerminalRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # The ID of the terminal to release.
     terminal_id: Annotated[str, Field(alias="terminalId", description="The ID of the terminal to release.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -268,18 +201,11 @@ class ReleaseTerminalRequest(BaseModel):
 
 
 class WaitForTerminalExitRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # The ID of the terminal to wait for.
     terminal_id: Annotated[
         str,
         Field(alias="terminalId", description="The ID of the terminal to wait for."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -290,15 +216,8 @@ class WaitForTerminalExitRequest(BaseModel):
 
 
 class KillTerminalRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # The ID of the terminal to kill.
     terminal_id: Annotated[str, Field(alias="terminalId", description="The ID of the terminal to kill.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -312,16 +231,10 @@ class CreateOtherElicitationRequest(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    # A human-readable message describing what input is needed.
     message: Annotated[
         str,
         Field(description="A human-readable message describing what input is needed."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -329,11 +242,6 @@ class CreateOtherElicitationRequest(BaseModel):
             description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
         ),
     ] = None
-    # Custom or future elicitation mode.
-    #
-    # Values beginning with `_` are reserved for implementation-specific
-    # extensions. Unknown values that do not begin with `_` are reserved for
-    # future ACP variants.
     mode: Annotated[
         str,
         Field(
@@ -353,12 +261,10 @@ class CreateOtherElicitationRequest(BaseModel):
 
 
 class ElicitationSessionScope(BaseModel):
-    # The session this elicitation is tied to.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session this elicitation is tied to."),
     ]
-    # Optional tool call within the session.
     tool_call_id: Annotated[
         Optional[str],
         Field(alias="toolCallId", description="Optional tool call within the session."),
@@ -371,7 +277,6 @@ class ElicitationSessionScope(BaseModel):
 
 
 class ElicitationRequestScope(BaseModel):
-    # The request this elicitation is tied to.
     request_id: Annotated[
         Optional[Union[int, str]],
         Field(alias="requestId", description="The request this elicitation is tied to."),
@@ -382,11 +287,6 @@ class ElicitationOtherPropertySchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    # Custom or future elicitation property schema type.
-    #
-    # Values beginning with `_` are reserved for implementation-specific
-    # extensions. Unknown values that do not begin with `_` are reserved for
-    # future ACP variants.
     type: Annotated[
         str,
         Field(
@@ -406,17 +306,9 @@ class ElicitationOtherPropertySchema(BaseModel):
 
 
 class EnumOption(BaseModel):
-    # The constant value for this option.
     const: Annotated[str, Field(description="The constant value for this option.")]
-    # Human-readable title for this option.
     title: Annotated[str, Field(description="Human-readable title for this option.")]
-    # Human-readable description.
     description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -432,32 +324,23 @@ class EnumOption(BaseModel):
 
 
 class StringPropertySchema(BaseModel):
-    # Optional title for the property.
     title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    # Human-readable description.
     description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    # Minimum string length.
     min_length: Annotated[
         Optional[int],
         Field(alias="minLength", description="Minimum string length.", ge=0),
     ] = None
-    # Maximum string length.
     max_length: Annotated[
         Optional[int],
         Field(alias="maxLength", description="Maximum string length.", ge=0),
     ] = None
-    # Pattern the string must match.
     pattern: Annotated[Optional[str], Field(description="Pattern the string must match.")] = None
-    # String format.
     format: Annotated[Optional[str], Field(description="String format.")] = None
-    # Default value.
     default: Annotated[Optional[str], Field(description="Default value.")] = None
-    # Enum values for untitled single-select enums.
     enum: Annotated[
         Optional[List[str]],
         Field(description="Enum values for untitled single-select enums."),
     ] = None
-    # Titled enum options for titled single-select enums.
     one_of: Annotated[
         Optional[List[EnumOption]],
         Field(
@@ -465,11 +348,6 @@ class StringPropertySchema(BaseModel):
             description="Titled enum options for titled single-select enums.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -485,21 +363,11 @@ class StringPropertySchema(BaseModel):
 
 
 class NumberPropertySchema(BaseModel):
-    # Optional title for the property.
     title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    # Human-readable description.
     description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    # Minimum value (inclusive).
     minimum: Annotated[Optional[float], Field(description="Minimum value (inclusive).")] = None
-    # Maximum value (inclusive).
     maximum: Annotated[Optional[float], Field(description="Maximum value (inclusive).")] = None
-    # Default value.
     default: Annotated[Optional[float], Field(description="Default value.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -515,21 +383,11 @@ class NumberPropertySchema(BaseModel):
 
 
 class IntegerPropertySchema(BaseModel):
-    # Optional title for the property.
     title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    # Human-readable description.
     description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    # Minimum value (inclusive).
     minimum: Annotated[Optional[int], Field(description="Minimum value (inclusive).")] = None
-    # Maximum value (inclusive).
     maximum: Annotated[Optional[int], Field(description="Maximum value (inclusive).")] = None
-    # Default value.
     default: Annotated[Optional[int], Field(description="Default value.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -545,17 +403,9 @@ class IntegerPropertySchema(BaseModel):
 
 
 class BooleanPropertySchema(BaseModel):
-    # Optional title for the property.
     title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    # Human-readable description.
     description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    # Default value.
     default: Annotated[Optional[bool], Field(description="Default value.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -574,11 +424,6 @@ class OtherMultiSelectItems(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    # Custom or future multi-select item type.
-    #
-    # Values beginning with `_` are reserved for implementation-specific
-    # extensions. Unknown values that do not begin with `_` are reserved for
-    # future ACP variants.
     type: Annotated[
         str,
         Field(
@@ -598,13 +443,7 @@ class OtherMultiSelectItems(BaseModel):
 
 
 class _StringMultiSelectItems(BaseModel):
-    # Allowed enum values.
     enum: Annotated[List[str], Field(description="Allowed enum values.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -615,13 +454,7 @@ class _StringMultiSelectItems(BaseModel):
 
 
 class TitledMultiSelectItems(BaseModel):
-    # Titled enum options.
     any_of: Annotated[List[EnumOption], Field(alias="anyOf", description="Titled enum options.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -632,7 +465,6 @@ class TitledMultiSelectItems(BaseModel):
 
 
 class ElicitationUrlSessionMode(ElicitationSessionScope):
-    # The unique identifier for this elicitation.
     elicitation_id: Annotated[
         str,
         Field(
@@ -640,12 +472,10 @@ class ElicitationUrlSessionMode(ElicitationSessionScope):
             description="The unique identifier for this elicitation.",
         ),
     ]
-    # The URL to direct the user to.
     url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
 
 
 class ElicitationUrlRequestMode(ElicitationRequestScope):
-    # The unique identifier for this elicitation.
     elicitation_id: Annotated[
         str,
         Field(
@@ -653,16 +483,10 @@ class ElicitationUrlRequestMode(ElicitationRequestScope):
             description="The unique identifier for this elicitation.",
         ),
     ]
-    # The URL to direct the user to.
     url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
 
 
 class ElicitationUrlMode(RootModel[Union[ElicitationUrlSessionMode, ElicitationUrlRequestMode]]):
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # URL-based elicitation mode where the client directs the user to a URL.
     root: Annotated[
         Union[ElicitationUrlSessionMode, ElicitationUrlRequestMode],
         Field(
@@ -672,16 +496,10 @@ class ElicitationUrlMode(RootModel[Union[ElicitationUrlSessionMode, ElicitationU
 
 
 class DisconnectMcpRequest(BaseModel):
-    # The MCP-over-ACP connection to close.
     connection_id: Annotated[
         str,
         Field(alias="connectionId", description="The MCP-over-ACP connection to close."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -692,14 +510,8 @@ class DisconnectMcpRequest(BaseModel):
 
 
 class PromptCapabilities(BaseModel):
-    # Agent supports [`ContentBlock::Image`].
     image: Annotated[Optional[bool], Field(description="Agent supports [`ContentBlock::Image`].")] = False
-    # Agent supports [`ContentBlock::Audio`].
     audio: Annotated[Optional[bool], Field(description="Agent supports [`ContentBlock::Audio`].")] = False
-    # Agent supports embedded context in `session/prompt` requests.
-    #
-    # When enabled, the Client is allowed to include [`ContentBlock::Resource`]
-    # in prompt requests for pieces of context that are referenced in the message.
     embedded_context: Annotated[
         Optional[bool],
         Field(
@@ -707,11 +519,6 @@ class PromptCapabilities(BaseModel):
             description="Agent supports embedded context in `session/prompt` requests.\n\nWhen enabled, the Client is allowed to include [`ContentBlock::Resource`]\nin prompt requests for pieces of context that are referenced in the message.",
         ),
     ] = False
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -727,26 +534,14 @@ class PromptCapabilities(BaseModel):
 
 
 class McpCapabilities(BaseModel):
-    # Agent supports [`McpServer::Http`].
     http: Annotated[Optional[bool], Field(description="Agent supports [`McpServer::Http`].")] = False
-    # Agent supports [`McpServer::Sse`].
     sse: Annotated[Optional[bool], Field(description="Agent supports [`McpServer::Sse`].")] = False
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Agent supports [`McpServer::Acp`].
     acp: Annotated[
         Optional[bool],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAgent supports [`McpServer::Acp`]."
         ),
     ] = False
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -762,11 +557,6 @@ class McpCapabilities(BaseModel):
 
 
 class SessionListCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -777,11 +567,6 @@ class SessionListCapabilities(BaseModel):
 
 
 class SessionDeleteCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -792,11 +577,6 @@ class SessionDeleteCapabilities(BaseModel):
 
 
 class SessionAdditionalDirectoriesCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -807,11 +587,6 @@ class SessionAdditionalDirectoriesCapabilities(BaseModel):
 
 
 class SessionForkCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -822,11 +597,6 @@ class SessionForkCapabilities(BaseModel):
 
 
 class SessionResumeCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -837,11 +607,6 @@ class SessionResumeCapabilities(BaseModel):
 
 
 class SessionCloseCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -852,11 +617,6 @@ class SessionCloseCapabilities(BaseModel):
 
 
 class LogoutCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -867,11 +627,6 @@ class LogoutCapabilities(BaseModel):
 
 
 class ProvidersCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -882,11 +637,6 @@ class ProvidersCapabilities(BaseModel):
 
 
 class NesDocumentDidOpenCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -897,11 +647,6 @@ class NesDocumentDidOpenCapabilities(BaseModel):
 
 
 class NesDocumentDidCloseCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -912,11 +657,6 @@ class NesDocumentDidCloseCapabilities(BaseModel):
 
 
 class NesDocumentDidSaveCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -927,11 +667,6 @@ class NesDocumentDidSaveCapabilities(BaseModel):
 
 
 class NesDocumentDidFocusCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -942,7 +677,6 @@ class NesDocumentDidFocusCapabilities(BaseModel):
 
 
 class NesRecentFilesCapabilities(BaseModel):
-    # Maximum number of recent files the agent can use.
     max_count: Annotated[
         Optional[int],
         Field(
@@ -951,11 +685,6 @@ class NesRecentFilesCapabilities(BaseModel):
             ge=0,
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -971,11 +700,6 @@ class NesRecentFilesCapabilities(BaseModel):
 
 
 class NesRelatedSnippetsCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -986,7 +710,6 @@ class NesRelatedSnippetsCapabilities(BaseModel):
 
 
 class NesEditHistoryCapabilities(BaseModel):
-    # Maximum number of edit history entries the agent can use.
     max_count: Annotated[
         Optional[int],
         Field(
@@ -995,11 +718,6 @@ class NesEditHistoryCapabilities(BaseModel):
             ge=0,
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1015,7 +733,6 @@ class NesEditHistoryCapabilities(BaseModel):
 
 
 class NesUserActionsCapabilities(BaseModel):
-    # Maximum number of user actions the agent can use.
     max_count: Annotated[
         Optional[int],
         Field(
@@ -1024,11 +741,6 @@ class NesUserActionsCapabilities(BaseModel):
             ge=0,
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1044,11 +756,6 @@ class NesUserActionsCapabilities(BaseModel):
 
 
 class NesOpenFilesCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1059,11 +766,6 @@ class NesOpenFilesCapabilities(BaseModel):
 
 
 class NesDiagnosticsCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1074,38 +776,24 @@ class NesDiagnosticsCapabilities(BaseModel):
 
 
 class AuthEnvVar(BaseModel):
-    # The environment variable name (e.g. `"OPENAI_API_KEY"`).
     name: Annotated[
         str,
         Field(description='The environment variable name (e.g. `"OPENAI_API_KEY"`).'),
     ]
-    # Human-readable label for this variable, displayed in client UI.
     label: Annotated[
         Optional[str],
         Field(description="Human-readable label for this variable, displayed in client UI."),
     ] = None
-    # Whether this value is a secret (e.g. API key, token).
-    # Clients should use a password-style input for secret vars.
-    #
-    # Defaults to `true`.
     secret: Annotated[
         Optional[bool],
         Field(
             description="Whether this value is a secret (e.g. API key, token).\nClients should use a password-style input for secret vars.\n\nDefaults to `true`."
         ),
     ] = True
-    # Whether this variable is optional.
-    #
-    # Defaults to `false`.
     optional: Annotated[
         Optional[bool],
         Field(description="Whether this variable is optional.\n\nDefaults to `false`."),
     ] = False
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1131,30 +819,20 @@ class AuthEnvVar(BaseModel):
 
 
 class AuthMethodEnvVar(BaseModel):
-    # Unique identifier for this authentication method.
     id: Annotated[str, Field(description="Unique identifier for this authentication method.")]
-    # Human-readable name of the authentication method.
     name: Annotated[str, Field(description="Human-readable name of the authentication method.")]
-    # Optional description providing more details about this authentication method.
     description: Annotated[
         Optional[str],
         Field(description="Optional description providing more details about this authentication method."),
     ] = None
-    # The environment variables the client should set.
     vars: Annotated[
         List[AuthEnvVar],
         Field(description="The environment variables the client should set."),
     ]
-    # Optional link to a page where the user can obtain their credentials.
     link: Annotated[
         Optional[str],
         Field(description="Optional link to a page where the user can obtain their credentials."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1175,30 +853,20 @@ class AuthMethodEnvVar(BaseModel):
 
 
 class AuthMethodTerminal(BaseModel):
-    # Unique identifier for this authentication method.
     id: Annotated[str, Field(description="Unique identifier for this authentication method.")]
-    # Human-readable name of the authentication method.
     name: Annotated[str, Field(description="Human-readable name of the authentication method.")]
-    # Optional description providing more details about this authentication method.
     description: Annotated[
         Optional[str],
         Field(description="Optional description providing more details about this authentication method."),
     ] = None
-    # Additional arguments to pass when running the agent binary for terminal auth.
     args: Annotated[
         Optional[List[str]],
         Field(description="Additional arguments to pass when running the agent binary for terminal auth."),
     ] = None
-    # Additional environment variables to set when running the agent binary for terminal auth.
     env: Annotated[
         Optional[Dict[str, str]],
         Field(description="Additional environment variables to set when running the agent binary for terminal auth."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1219,20 +887,12 @@ class AuthMethodTerminal(BaseModel):
 
 
 class AuthMethodAgent(BaseModel):
-    # Unique identifier for this authentication method.
     id: Annotated[str, Field(description="Unique identifier for this authentication method.")]
-    # Human-readable name of the authentication method.
     name: Annotated[str, Field(description="Human-readable name of the authentication method.")]
-    # Optional description providing more details about this authentication method.
     description: Annotated[
         Optional[str],
         Field(description="Optional description providing more details about this authentication method."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1248,37 +908,24 @@ class AuthMethodAgent(BaseModel):
 
 
 class Implementation(BaseModel):
-    # Intended for programmatic or logical use, but can be used as a display
-    # name fallback if title isn’t present.
     name: Annotated[
         str,
         Field(
             description="Intended for programmatic or logical use, but can be used as a display\nname fallback if title isn’t present."
         ),
     ]
-    # Intended for UI and end-user contexts — optimized to be human-readable
-    # and easily understood.
-    #
-    # If not provided, the name should be used for display.
     title: Annotated[
         Optional[str],
         Field(
             description="Intended for UI and end-user contexts — optimized to be human-readable\nand easily understood.\n\nIf not provided, the name should be used for display."
         ),
     ] = None
-    # Version of the implementation. Can be displayed to the user or used
-    # for debugging or metrics purposes. (e.g. "1.0.0").
     version: Annotated[
         str,
         Field(
             description='Version of the implementation. Can be displayed to the user or used\nfor debugging or metrics purposes. (e.g. "1.0.0").'
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1294,11 +941,6 @@ class Implementation(BaseModel):
 
 
 class AuthenticateResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1309,7 +951,6 @@ class AuthenticateResponse(BaseModel):
 
 
 class ProviderCurrentConfig(BaseModel):
-    # Protocol currently used by this provider.
     api_type: Annotated[
         Union[
             Literal["anthropic"],
@@ -1321,16 +962,10 @@ class ProviderCurrentConfig(BaseModel):
         ],
         Field(alias="apiType", description="Protocol currently used by this provider."),
     ]
-    # Base URL currently used by this provider.
     base_url: Annotated[
         str,
         Field(alias="baseUrl", description="Base URL currently used by this provider."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1341,11 +976,6 @@ class ProviderCurrentConfig(BaseModel):
 
 
 class SetProviderResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1356,11 +986,6 @@ class SetProviderResponse(BaseModel):
 
 
 class DisableProviderResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1371,11 +996,6 @@ class DisableProviderResponse(BaseModel):
 
 
 class LogoutResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1386,23 +1006,15 @@ class LogoutResponse(BaseModel):
 
 
 class SessionMode(BaseModel):
-    # Stable identifier used to refer to this protocol object in later messages.
     id: Annotated[
         str,
         Field(description="Stable identifier used to refer to this protocol object in later messages."),
     ]
-    # Human-readable name shown for this protocol object.
     name: Annotated[str, Field(description="Human-readable name shown for this protocol object.")]
-    # Optional human-readable details shown with this protocol object.
     description: Annotated[
         Optional[str],
         Field(description="Optional human-readable details shown with this protocol object."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1418,17 +1030,9 @@ class SessionMode(BaseModel):
 
 
 class SessionConfigSelectOption(BaseModel):
-    # Unique identifier for this option value.
     value: Annotated[str, Field(description="Unique identifier for this option value.")]
-    # Human-readable label for this option value.
     name: Annotated[str, Field(description="Human-readable label for this option value.")]
-    # Optional description for this option value.
     description: Annotated[Optional[str], Field(description="Optional description for this option value.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1444,7 +1048,6 @@ class SessionConfigSelectOption(BaseModel):
 
 
 class SessionConfigBoolean(BaseModel):
-    # The current value of the boolean option.
     current_value: Annotated[
         bool,
         Field(alias="currentValue", description="The current value of the boolean option."),
@@ -1452,18 +1055,11 @@ class SessionConfigBoolean(BaseModel):
 
 
 class SessionInfo(BaseModel):
-    # Unique identifier for the session
     session_id: Annotated[str, Field(alias="sessionId", description="Unique identifier for the session")]
-    # The working directory for this session. Must be an absolute path.
     cwd: Annotated[
         str,
         Field(description="The working directory for this session. Must be an absolute path."),
     ]
-    # Additional workspace roots reported for this session. Each path must be absolute.
-    #
-    # When present, this is the complete ordered additional-root list reported
-    # by the Agent. Omitted and empty values are equivalent: the response
-    # reports no additional roots.
     additional_directories: Annotated[
         Optional[List[str]],
         Field(
@@ -1471,18 +1067,11 @@ class SessionInfo(BaseModel):
             description="Additional workspace roots reported for this session. Each path must be absolute.\n\nWhen present, this is the complete ordered additional-root list reported\nby the Agent. Omitted and empty values are equivalent: the response\nreports no additional roots.",
         ),
     ] = None
-    # Human-readable title for the session
     title: Annotated[Optional[str], Field(description="Human-readable title for the session")] = None
-    # ISO 8601 timestamp of last activity
     updated_at: Annotated[
         Optional[str],
         Field(alias="updatedAt", description="ISO 8601 timestamp of last activity"),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1503,11 +1092,6 @@ class SessionInfo(BaseModel):
 
 
 class DeleteSessionResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1518,11 +1102,6 @@ class DeleteSessionResponse(BaseModel):
 
 
 class CloseSessionResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1533,11 +1112,6 @@ class CloseSessionResponse(BaseModel):
 
 
 class SetSessionModeResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1548,7 +1122,6 @@ class SetSessionModeResponse(BaseModel):
 
 
 class Usage(BaseModel):
-    # Sum of all token types across session.
     total_tokens: Annotated[
         int,
         Field(
@@ -1557,7 +1130,6 @@ class Usage(BaseModel):
             ge=0,
         ),
     ]
-    # Total input tokens across all turns.
     input_tokens: Annotated[
         int,
         Field(
@@ -1566,7 +1138,6 @@ class Usage(BaseModel):
             ge=0,
         ),
     ]
-    # Total output tokens across all turns.
     output_tokens: Annotated[
         int,
         Field(
@@ -1575,26 +1146,18 @@ class Usage(BaseModel):
             ge=0,
         ),
     ]
-    # Total thought/reasoning tokens
     thought_tokens: Annotated[
         Optional[int],
         Field(alias="thoughtTokens", description="Total thought/reasoning tokens", ge=0),
     ] = None
-    # Total cache read tokens.
     cached_read_tokens: Annotated[
         Optional[int],
         Field(alias="cachedReadTokens", description="Total cache read tokens.", ge=0),
     ] = None
-    # Total cache write tokens.
     cached_write_tokens: Annotated[
         Optional[int],
         Field(alias="cachedWriteTokens", description="Total cache write tokens.", ge=0),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1610,7 +1173,6 @@ class Usage(BaseModel):
 
 
 class StartNesResponse(BaseModel):
-    # The session ID for the newly started NES session.
     session_id: Annotated[
         str,
         Field(
@@ -1618,11 +1180,6 @@ class StartNesResponse(BaseModel):
             description="The session ID for the newly started NES session.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1633,18 +1190,11 @@ class StartNesResponse(BaseModel):
 
 
 class Position(BaseModel):
-    # Zero-based line number.
     line: Annotated[int, Field(description="Zero-based line number.", ge=0)]
-    # Zero-based character offset (encoding-dependent).
     character: Annotated[
         int,
         Field(description="Zero-based character offset (encoding-dependent).", ge=0),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1655,17 +1205,9 @@ class Position(BaseModel):
 
 
 class NesJumpSuggestion(BaseModel):
-    # Unique identifier for accept/reject tracking.
     id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    # The file to navigate to.
     uri: Annotated[str, Field(description="The file to navigate to.")]
-    # The target position within the file.
     position: Annotated[Position, Field(description="The target position within the file.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1676,19 +1218,10 @@ class NesJumpSuggestion(BaseModel):
 
 
 class NesRenameSuggestion(BaseModel):
-    # Unique identifier for accept/reject tracking.
     id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    # The file URI containing the symbol.
     uri: Annotated[str, Field(description="The file URI containing the symbol.")]
-    # The position of the symbol to rename.
     position: Annotated[Position, Field(description="The position of the symbol to rename.")]
-    # The new name for the symbol.
     new_name: Annotated[str, Field(alias="newName", description="The new name for the symbol.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1699,15 +1232,10 @@ class NesRenameSuggestion(BaseModel):
 
 
 class NesSearchAndReplaceSuggestion(BaseModel):
-    # Unique identifier for accept/reject tracking.
     id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    # The file URI to search within.
     uri: Annotated[str, Field(description="The file URI to search within.")]
-    # The text or pattern to find.
     search: Annotated[str, Field(description="The text or pattern to find.")]
-    # The replacement text.
     replace: Annotated[str, Field(description="The replacement text.")]
-    # Whether `search` is a regular expression. Defaults to `false`.
     is_regex: Annotated[
         Optional[bool],
         Field(
@@ -1715,11 +1243,6 @@ class NesSearchAndReplaceSuggestion(BaseModel):
             description="Whether `search` is a regular expression. Defaults to `false`.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1730,11 +1253,6 @@ class NesSearchAndReplaceSuggestion(BaseModel):
 
 
 class CloseNesResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1745,15 +1263,8 @@ class CloseNesResponse(BaseModel):
 
 
 class PlanFile(BaseModel):
-    # The plan ID to update.
     plan_id: Annotated[str, Field(alias="planId", description="The plan ID to update.")]
-    # The URI of the file containing the plan.
     uri: Annotated[str, Field(description="The URI of the file containing the plan.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1764,15 +1275,8 @@ class PlanFile(BaseModel):
 
 
 class PlanMarkdown(BaseModel):
-    # The plan ID to update.
     plan_id: Annotated[str, Field(alias="planId", description="The plan ID to update.")]
-    # Markdown content for the plan.
     content: Annotated[str, Field(description="Markdown content for the plan.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1783,13 +1287,7 @@ class PlanMarkdown(BaseModel):
 
 
 class PlanRemoved(BaseModel):
-    # The plan ID to remove.
     plan_id: Annotated[str, Field(alias="planId", description="The plan ID to remove.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1800,16 +1298,10 @@ class PlanRemoved(BaseModel):
 
 
 class UnstructuredCommandInput(BaseModel):
-    # A hint to display when the input hasn't been provided yet
     hint: Annotated[
         str,
         Field(description="A hint to display when the input hasn't been provided yet"),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1820,13 +1312,7 @@ class UnstructuredCommandInput(BaseModel):
 
 
 class _CurrentModeUpdate(BaseModel):
-    # The ID of the current mode
     current_mode_id: Annotated[str, Field(alias="currentModeId", description="The ID of the current mode")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1837,12 +1323,10 @@ class _CurrentModeUpdate(BaseModel):
 
 
 class _SessionInfoUpdate(BaseModel):
-    # Human-readable title for the session. Set to null to clear.
     title: Annotated[
         Optional[str],
         Field(description="Human-readable title for the session. Set to null to clear."),
     ] = None
-    # ISO 8601 timestamp of last activity. Set to null to clear.
     updated_at: Annotated[
         Optional[str],
         Field(
@@ -1850,11 +1334,6 @@ class _SessionInfoUpdate(BaseModel):
             description="ISO 8601 timestamp of last activity. Set to null to clear.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1870,15 +1349,8 @@ class _SessionInfoUpdate(BaseModel):
 
 
 class Cost(BaseModel):
-    # Total cumulative cost for session.
     amount: Annotated[float, Field(description="Total cumulative cost for session.")]
-    # ISO 4217 currency code (e.g., "USD", "EUR").
     currency: Annotated[str, Field(description='ISO 4217 currency code (e.g., "USD", "EUR").')]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1889,17 +1361,9 @@ class Cost(BaseModel):
 
 
 class _UsageUpdate(BaseModel):
-    # Tokens currently in context.
     used: Annotated[int, Field(description="Tokens currently in context.", ge=0)]
-    # Total context window size in tokens.
     size: Annotated[int, Field(description="Total context window size in tokens.", ge=0)]
-    # Cumulative session cost (optional).
     cost: Annotated[Optional[Cost], Field(description="Cumulative session cost (optional).")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1915,7 +1379,6 @@ class _UsageUpdate(BaseModel):
 
 
 class CompleteElicitationNotification(BaseModel):
-    # The ID of the elicitation that completed.
     elicitation_id: Annotated[
         str,
         Field(
@@ -1923,11 +1386,6 @@ class CompleteElicitationNotification(BaseModel):
             description="The ID of the elicitation that completed.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1938,7 +1396,6 @@ class CompleteElicitationNotification(BaseModel):
 
 
 class MessageMcpNotification(BaseModel):
-    # The MCP-over-ACP connection this message is sent on.
     connection_id: Annotated[
         str,
         Field(
@@ -1946,22 +1403,13 @@ class MessageMcpNotification(BaseModel):
             description="The MCP-over-ACP connection this message is sent on.",
         ),
     ]
-    # The inner MCP method name.
     method: Annotated[str, Field(description="The inner MCP method name.")]
-    # Optional inner MCP params.
-    #
-    # If omitted or set to `null`, the inner MCP message has no params.
     params: Annotated[
         Optional[Dict[str, Any]],
         Field(
             description="Optional inner MCP params.\n\nIf omitted or set to `null`, the inner MCP message has no params."
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -1977,7 +1425,6 @@ class MessageMcpNotification(BaseModel):
 
 
 class FileSystemCapabilities(BaseModel):
-    # Whether the Client supports `fs/read_text_file` requests.
     read_text_file: Annotated[
         Optional[bool],
         Field(
@@ -1985,7 +1432,6 @@ class FileSystemCapabilities(BaseModel):
             description="Whether the Client supports `fs/read_text_file` requests.",
         ),
     ] = False
-    # Whether the Client supports `fs/write_text_file` requests.
     write_text_file: Annotated[
         Optional[bool],
         Field(
@@ -1993,11 +1439,6 @@ class FileSystemCapabilities(BaseModel):
             description="Whether the Client supports `fs/write_text_file` requests.",
         ),
     ] = False
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2013,11 +1454,6 @@ class FileSystemCapabilities(BaseModel):
 
 
 class BooleanConfigOptionCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2028,11 +1464,6 @@ class BooleanConfigOptionCapabilities(BaseModel):
 
 
 class PlanCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2043,20 +1474,12 @@ class PlanCapabilities(BaseModel):
 
 
 class AuthCapabilities(BaseModel):
-    # Whether the client supports `terminal` authentication methods.
-    #
-    # When `true`, the agent may include `terminal` entries in its authentication methods.
     terminal: Annotated[
         Optional[bool],
         Field(
             description="Whether the client supports `terminal` authentication methods.\n\nWhen `true`, the agent may include `terminal` entries in its authentication methods."
         ),
     ] = False
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2072,11 +1495,6 @@ class AuthCapabilities(BaseModel):
 
 
 class ElicitationFormCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2087,11 +1505,6 @@ class ElicitationFormCapabilities(BaseModel):
 
 
 class ElicitationUrlCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2102,11 +1515,6 @@ class ElicitationUrlCapabilities(BaseModel):
 
 
 class NesJumpCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2117,11 +1525,6 @@ class NesJumpCapabilities(BaseModel):
 
 
 class NesRenameCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2132,11 +1535,6 @@ class NesRenameCapabilities(BaseModel):
 
 
 class NesSearchAndReplaceCapabilities(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2147,8 +1545,6 @@ class NesSearchAndReplaceCapabilities(BaseModel):
 
 
 class AuthenticateRequest(BaseModel):
-    # The ID of the authentication method to use.
-    # Must be one of the methods advertised in the initialize response.
     method_id: Annotated[
         str,
         Field(
@@ -2156,11 +1552,6 @@ class AuthenticateRequest(BaseModel):
             description="The ID of the authentication method to use.\nMust be one of the methods advertised in the initialize response.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2171,11 +1562,6 @@ class AuthenticateRequest(BaseModel):
 
 
 class ListProvidersRequest(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2186,9 +1572,7 @@ class ListProvidersRequest(BaseModel):
 
 
 class SetProviderRequest(BaseModel):
-    # Provider ID to configure.
     provider_id: Annotated[str, Field(alias="providerId", description="Provider ID to configure.")]
-    # Protocol type for this provider.
     api_type: Annotated[
         Union[
             Literal["anthropic"],
@@ -2200,7 +1584,6 @@ class SetProviderRequest(BaseModel):
         ],
         Field(alias="apiType", description="Protocol type for this provider."),
     ]
-    # Base URL for requests sent through this provider.
     base_url: Annotated[
         str,
         Field(
@@ -2208,19 +1591,12 @@ class SetProviderRequest(BaseModel):
             description="Base URL for requests sent through this provider.",
         ),
     ]
-    # Full headers map for this provider.
-    # May include authorization, routing, or other integration-specific headers.
     headers: Annotated[
         Optional[Dict[str, str]],
         Field(
             description="Full headers map for this provider.\nMay include authorization, routing, or other integration-specific headers."
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2231,13 +1607,7 @@ class SetProviderRequest(BaseModel):
 
 
 class DisableProviderRequest(BaseModel):
-    # Provider ID to disable.
     provider_id: Annotated[str, Field(alias="providerId", description="Provider ID to disable.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2248,11 +1618,6 @@ class DisableProviderRequest(BaseModel):
 
 
 class LogoutRequest(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2263,15 +1628,8 @@ class LogoutRequest(BaseModel):
 
 
 class HttpHeader(BaseModel):
-    # The name of the HTTP header.
     name: Annotated[str, Field(description="The name of the HTTP header.")]
-    # The value to set for the HTTP header.
     value: Annotated[str, Field(description="The value to set for the HTTP header.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2282,20 +1640,12 @@ class HttpHeader(BaseModel):
 
 
 class McpServerHttp(BaseModel):
-    # Human-readable name identifying this MCP server.
     name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    # URL to the MCP server.
     url: Annotated[str, Field(description="URL to the MCP server.")]
-    # HTTP headers to set when making requests to the MCP server.
     headers: Annotated[
         List[HttpHeader],
         Field(description="HTTP headers to set when making requests to the MCP server."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2306,20 +1656,12 @@ class McpServerHttp(BaseModel):
 
 
 class McpServerSse(BaseModel):
-    # Human-readable name identifying this MCP server.
     name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    # URL to the MCP server.
     url: Annotated[str, Field(description="URL to the MCP server.")]
-    # HTTP headers to set when making requests to the MCP server.
     headers: Annotated[
         List[HttpHeader],
         Field(description="HTTP headers to set when making requests to the MCP server."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2330,12 +1672,7 @@ class McpServerSse(BaseModel):
 
 
 class McpServerAcp(BaseModel):
-    # Human-readable name identifying this MCP server.
     name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    # Unique identifier for this MCP server, generated by the component providing it.
-    #
-    # Providers MUST NOT reuse an ID for multiple ACP-transport MCP servers that are visible
-    # on the same ACP connection.
     server_id: Annotated[
         str,
         Field(
@@ -2343,11 +1680,6 @@ class McpServerAcp(BaseModel):
             description="Unique identifier for this MCP server, generated by the component providing it.\n\nProviders MUST NOT reuse an ID for multiple ACP-transport MCP servers that are visible\non the same ACP connection.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2358,25 +1690,16 @@ class McpServerAcp(BaseModel):
 
 
 class McpServerStdio(BaseModel):
-    # Human-readable name identifying this MCP server.
     name: Annotated[str, Field(description="Human-readable name identifying this MCP server.")]
-    # Absolute path to the MCP server executable.
     command: Annotated[str, Field(description="Absolute path to the MCP server executable.")]
-    # Command-line arguments to pass to the MCP server.
     args: Annotated[
         List[str],
         Field(description="Command-line arguments to pass to the MCP server."),
     ]
-    # Environment variables to set when launching the MCP server.
     env: Annotated[
         List[EnvVariable],
         Field(description="Environment variables to set when launching the MCP server."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2387,23 +1710,16 @@ class McpServerStdio(BaseModel):
 
 
 class ListSessionsRequest(BaseModel):
-    # Filter sessions by working directory. Must be an absolute path.
     cwd: Annotated[
         Optional[str],
         Field(description="Filter sessions by working directory. Must be an absolute path."),
     ] = None
-    # Opaque cursor token from a previous response's nextCursor field for cursor-based pagination
     cursor: Annotated[
         Optional[str],
         Field(
             description="Opaque cursor token from a previous response's nextCursor field for cursor-based pagination"
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2414,13 +1730,7 @@ class ListSessionsRequest(BaseModel):
 
 
 class DeleteSessionRequest(BaseModel):
-    # The ID of the session to delete.
     session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to delete.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2431,13 +1741,7 @@ class DeleteSessionRequest(BaseModel):
 
 
 class CloseSessionRequest(BaseModel):
-    # The ID of the session to close.
     session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to close.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2448,18 +1752,11 @@ class CloseSessionRequest(BaseModel):
 
 
 class SetSessionModeRequest(BaseModel):
-    # The ID of the session to set the mode for.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The ID of the session to set the mode for."),
     ]
-    # The ID of the mode to set.
     mode_id: Annotated[str, Field(alias="modeId", description="The ID of the mode to set.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2470,7 +1767,6 @@ class SetSessionModeRequest(BaseModel):
 
 
 class SetSessionConfigOptionBooleanRequest(BaseModel):
-    # The ID of the session to set the configuration option for.
     session_id: Annotated[
         str,
         Field(
@@ -2478,16 +1774,10 @@ class SetSessionConfigOptionBooleanRequest(BaseModel):
             description="The ID of the session to set the configuration option for.",
         ),
     ]
-    # The ID of the configuration option to set.
     config_id: Annotated[
         str,
         Field(alias="configId", description="The ID of the configuration option to set."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2495,13 +1785,11 @@ class SetSessionConfigOptionBooleanRequest(BaseModel):
             description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
         ),
     ] = None
-    # The boolean value.
     value: Annotated[bool, Field(description="The boolean value.")]
     type: Literal["boolean"]
 
 
 class SetSessionConfigOptionSelectRequest(BaseModel):
-    # The ID of the session to set the configuration option for.
     session_id: Annotated[
         str,
         Field(
@@ -2509,16 +1797,10 @@ class SetSessionConfigOptionSelectRequest(BaseModel):
             description="The ID of the session to set the configuration option for.",
         ),
     ]
-    # The ID of the configuration option to set.
     config_id: Annotated[
         str,
         Field(alias="configId", description="The ID of the configuration option to set."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2526,20 +1808,12 @@ class SetSessionConfigOptionSelectRequest(BaseModel):
             description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
         ),
     ] = None
-    # The value ID.
     value: Annotated[str, Field(description="The value ID.")]
 
 
 class WorkspaceFolder(BaseModel):
-    # The URI of the folder.
     uri: Annotated[str, Field(description="The URI of the folder.")]
-    # The display name of the folder.
     name: Annotated[str, Field(description="The display name of the folder.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2550,17 +1824,9 @@ class WorkspaceFolder(BaseModel):
 
 
 class NesRepository(BaseModel):
-    # The repository name.
     name: Annotated[str, Field(description="The repository name.")]
-    # The repository owner.
     owner: Annotated[str, Field(description="The repository owner.")]
-    # The remote URL of the repository.
     remote_url: Annotated[str, Field(alias="remoteUrl", description="The remote URL of the repository.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2571,17 +1837,9 @@ class NesRepository(BaseModel):
 
 
 class NesRecentFile(BaseModel):
-    # The URI of the file.
     uri: Annotated[str, Field(description="The URI of the file.")]
-    # The language identifier.
     language_id: Annotated[str, Field(alias="languageId", description="The language identifier.")]
-    # The full text content of the file.
     text: Annotated[str, Field(description="The full text content of the file.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2592,7 +1850,6 @@ class NesRecentFile(BaseModel):
 
 
 class NesExcerpt(BaseModel):
-    # The start line of the excerpt (zero-based).
     start_line: Annotated[
         int,
         Field(
@@ -2601,7 +1858,6 @@ class NesExcerpt(BaseModel):
             ge=0,
         ),
     ]
-    # The end line of the excerpt (zero-based).
     end_line: Annotated[
         int,
         Field(
@@ -2610,13 +1866,7 @@ class NesExcerpt(BaseModel):
             ge=0,
         ),
     ]
-    # The text content of the excerpt.
     text: Annotated[str, Field(description="The text content of the excerpt.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2627,15 +1877,8 @@ class NesExcerpt(BaseModel):
 
 
 class NesEditHistoryEntry(BaseModel):
-    # The URI of the edited file.
     uri: Annotated[str, Field(description="The URI of the edited file.")]
-    # A diff representing the edit.
     diff: Annotated[str, Field(description="A diff representing the edit.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2646,16 +1889,12 @@ class NesEditHistoryEntry(BaseModel):
 
 
 class NesUserAction(BaseModel):
-    # The kind of action (e.g., "insertChar", "cursorMovement").
     action: Annotated[
         str,
         Field(description='The kind of action (e.g., "insertChar", "cursorMovement").'),
     ]
-    # The URI of the file where the action occurred.
     uri: Annotated[str, Field(description="The URI of the file where the action occurred.")]
-    # The position where the action occurred.
     position: Annotated[Position, Field(description="The position where the action occurred.")]
-    # Timestamp in milliseconds since epoch.
     timestamp_ms: Annotated[
         int,
         Field(
@@ -2664,11 +1903,6 @@ class NesUserAction(BaseModel):
             ge=0,
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2679,13 +1913,7 @@ class NesUserAction(BaseModel):
 
 
 class CloseNesRequest(BaseModel):
-    # The ID of the NES session to close.
     session_id: Annotated[str, Field(alias="sessionId", description="The ID of the NES session to close.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2696,11 +1924,6 @@ class CloseNesRequest(BaseModel):
 
 
 class WriteTextFileResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2711,13 +1934,7 @@ class WriteTextFileResponse(BaseModel):
 
 
 class ReadTextFileResponse(BaseModel):
-    # Content payload returned by this response.
     content: Annotated[str, Field(description="Content payload returned by this response.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2732,16 +1949,10 @@ class DeniedOutcome(BaseModel):
 
 
 class SelectedPermissionOutcome(BaseModel):
-    # The ID of the option the user selected.
     option_id: Annotated[
         str,
         Field(alias="optionId", description="The ID of the option the user selected."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2752,7 +1963,6 @@ class SelectedPermissionOutcome(BaseModel):
 
 
 class CreateTerminalResponse(BaseModel):
-    # The unique identifier for the created terminal.
     terminal_id: Annotated[
         str,
         Field(
@@ -2760,11 +1970,6 @@ class CreateTerminalResponse(BaseModel):
             description="The unique identifier for the created terminal.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2775,7 +1980,6 @@ class CreateTerminalResponse(BaseModel):
 
 
 class TerminalExitStatus(BaseModel):
-    # The process exit code (may be null if terminated by signal).
     exit_code: Annotated[
         Optional[int],
         Field(
@@ -2784,16 +1988,10 @@ class TerminalExitStatus(BaseModel):
             ge=0,
         ),
     ] = None
-    # The signal that terminated the process (may be null if exited normally).
     signal: Annotated[
         Optional[str],
         Field(description="The signal that terminated the process (may be null if exited normally)."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2809,11 +2007,6 @@ class TerminalExitStatus(BaseModel):
 
 
 class ReleaseTerminalResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2824,7 +2017,6 @@ class ReleaseTerminalResponse(BaseModel):
 
 
 class WaitForTerminalExitResponse(BaseModel):
-    # The process exit code (may be null if terminated by signal).
     exit_code: Annotated[
         Optional[int],
         Field(
@@ -2833,16 +2025,10 @@ class WaitForTerminalExitResponse(BaseModel):
             ge=0,
         ),
     ] = None
-    # The signal that terminated the process (may be null if exited normally).
     signal: Annotated[
         Optional[str],
         Field(description="The signal that terminated the process (may be null if exited normally)."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2858,11 +2044,6 @@ class WaitForTerminalExitResponse(BaseModel):
 
 
 class KillTerminalResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2873,11 +2054,6 @@ class KillTerminalResponse(BaseModel):
 
 
 class DeclineElicitationResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2889,11 +2065,6 @@ class DeclineElicitationResponse(BaseModel):
 
 
 class CancelElicitationResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2908,11 +2079,6 @@ class OtherElicitationResponse(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2920,11 +2086,6 @@ class OtherElicitationResponse(BaseModel):
             description="The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
         ),
     ] = None
-    # Custom or future elicitation action.
-    #
-    # Values beginning with `_` are reserved for implementation-specific
-    # extensions. Unknown values that do not begin with `_` are reserved for
-    # future ACP variants.
     action: Annotated[
         str,
         Field(
@@ -2944,7 +2105,6 @@ class OtherElicitationResponse(BaseModel):
 
 
 class ElicitationContentValue(RootModel[Union[str, int, float, bool, List[str]]]):
-    # Allowed wire representations for [`ElicitationContentValue`].
     root: Annotated[
         Union[str, int, float, bool, List[str]],
         Field(description="Allowed wire representations for [`ElicitationContentValue`]."),
@@ -2952,7 +2112,6 @@ class ElicitationContentValue(RootModel[Union[str, int, float, bool, List[str]]]
 
 
 class ElicitationAcceptAction(BaseModel):
-    # The user-provided content, if any, as an object matching the requested schema.
     content: Annotated[
         Optional[Dict[str, Any]],
         Field(description="The user-provided content, if any, as an object matching the requested schema."),
@@ -2960,7 +2119,6 @@ class ElicitationAcceptAction(BaseModel):
 
 
 class ConnectMcpResponse(BaseModel):
-    # The unique identifier for this MCP-over-ACP connection.
     connection_id: Annotated[
         str,
         Field(
@@ -2968,11 +2126,6 @@ class ConnectMcpResponse(BaseModel):
             description="The unique identifier for this MCP-over-ACP connection.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2983,11 +2136,6 @@ class ConnectMcpResponse(BaseModel):
 
 
 class DisconnectMcpResponse(BaseModel):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -2998,7 +2146,6 @@ class DisconnectMcpResponse(BaseModel):
 
 
 class CancelNotification(BaseModel):
-    # The ID of the session to cancel operations for.
     session_id: Annotated[
         str,
         Field(
@@ -3006,11 +2153,6 @@ class CancelNotification(BaseModel):
             description="The ID of the session to cancel operations for.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3021,14 +2163,11 @@ class CancelNotification(BaseModel):
 
 
 class DidOpenDocumentNotification(BaseModel):
-    # The session ID for this notification.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session ID for this notification."),
     ]
-    # The URI of the opened document.
     uri: Annotated[str, Field(description="The URI of the opened document.")]
-    # The language identifier of the document (e.g., "rust", "python").
     language_id: Annotated[
         str,
         Field(
@@ -3036,15 +2175,8 @@ class DidOpenDocumentNotification(BaseModel):
             description='The language identifier of the document (e.g., "rust", "python").',
         ),
     ]
-    # The version number of the document.
     version: Annotated[int, Field(description="The version number of the document.")]
-    # The full text content of the document.
     text: Annotated[str, Field(description="The full text content of the document.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3055,18 +2187,11 @@ class DidOpenDocumentNotification(BaseModel):
 
 
 class DidCloseDocumentNotification(BaseModel):
-    # The session ID for this notification.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session ID for this notification."),
     ]
-    # The URI of the closed document.
     uri: Annotated[str, Field(description="The URI of the closed document.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3077,18 +2202,11 @@ class DidCloseDocumentNotification(BaseModel):
 
 
 class DidSaveDocumentNotification(BaseModel):
-    # The session ID for this notification.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session ID for this notification."),
     ]
-    # The URI of the saved document.
     uri: Annotated[str, Field(description="The URI of the saved document.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3099,18 +2217,11 @@ class DidSaveDocumentNotification(BaseModel):
 
 
 class AcceptNesNotification(BaseModel):
-    # The session ID for this notification.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session ID for this notification."),
     ]
-    # The ID of the accepted suggestion.
     id: Annotated[str, Field(description="The ID of the accepted suggestion.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3121,16 +2232,10 @@ class AcceptNesNotification(BaseModel):
 
 
 class CancelRequestNotification(BaseModel):
-    # The ID of the request to cancel.
     request_id: Annotated[
         Optional[Union[int, str]],
         Field(alias="requestId", description="The ID of the request to cancel."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3141,17 +2246,9 @@ class CancelRequestNotification(BaseModel):
 
 
 class WriteTextFileRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # Absolute path to the file to write.
     path: Annotated[str, Field(description="Absolute path to the file to write.")]
-    # The text content to write to the file.
     content: Annotated[str, Field(description="The text content to write to the file.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3170,12 +2267,10 @@ class TerminalToolCallContent(Terminal):
 
 
 class Annotations(BaseModel):
-    # Intended recipients for this content, such as the user or assistant.
     audience: Annotated[
         Optional[List[str]],
         Field(description="Intended recipients for this content, such as the user or assistant."),
     ] = None
-    # Timestamp indicating when the underlying resource was last modified.
     last_modified: Annotated[
         Optional[str],
         Field(
@@ -3183,16 +2278,10 @@ class Annotations(BaseModel):
             description="Timestamp indicating when the underlying resource was last modified.",
         ),
     ] = None
-    # Relative importance of this content when clients choose what to surface.
     priority: Annotated[
         Optional[float],
         Field(description="Relative importance of this content when clients choose what to surface."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3213,18 +2302,11 @@ class Annotations(BaseModel):
 
 
 class TextContent(BaseModel):
-    # Optional annotations that help clients decide how to display or route this content.
     annotations: Annotated[
         Optional[Annotations],
         Field(description="Optional annotations that help clients decide how to display or route this content."),
     ] = None
-    # Text payload carried by this content block.
     text: Annotated[str, Field(description="Text payload carried by this content block.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3240,14 +2322,11 @@ class TextContent(BaseModel):
 
 
 class ImageContent(BaseModel):
-    # Optional annotations that help clients decide how to display or route this content.
     annotations: Annotated[
         Optional[Annotations],
         Field(description="Optional annotations that help clients decide how to display or route this content."),
     ] = None
-    # Base64-encoded media payload.
     data: Annotated[str, Field(description="Base64-encoded media payload.")]
-    # MIME type describing the encoded media payload.
     mime_type: Annotated[
         str,
         Field(
@@ -3255,16 +2334,10 @@ class ImageContent(BaseModel):
             description="MIME type describing the encoded media payload.",
         ),
     ]
-    # URI associated with this resource or media payload.
     uri: Annotated[
         Optional[str],
         Field(description="URI associated with this resource or media payload."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3280,14 +2353,11 @@ class ImageContent(BaseModel):
 
 
 class AudioContent(BaseModel):
-    # Optional annotations that help clients decide how to display or route this content.
     annotations: Annotated[
         Optional[Annotations],
         Field(description="Optional annotations that help clients decide how to display or route this content."),
     ] = None
-    # Base64-encoded media payload.
     data: Annotated[str, Field(description="Base64-encoded media payload.")]
-    # MIME type describing the encoded media payload.
     mime_type: Annotated[
         str,
         Field(
@@ -3295,11 +2365,6 @@ class AudioContent(BaseModel):
             description="MIME type describing the encoded media payload.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3315,17 +2380,14 @@ class AudioContent(BaseModel):
 
 
 class ResourceLink(BaseModel):
-    # Optional annotations that help clients decide how to display or route this content.
     annotations: Annotated[
         Optional[Annotations],
         Field(description="Optional annotations that help clients decide how to display or route this content."),
     ] = None
-    # Optional human-readable details shown with this protocol object.
     description: Annotated[
         Optional[str],
         Field(description="Optional human-readable details shown with this protocol object."),
     ] = None
-    # MIME type describing the encoded media payload.
     mime_type: Annotated[
         Optional[str],
         Field(
@@ -3333,22 +2395,13 @@ class ResourceLink(BaseModel):
             description="MIME type describing the encoded media payload.",
         ),
     ] = None
-    # Human-readable name shown for this protocol object.
     name: Annotated[str, Field(description="Human-readable name shown for this protocol object.")]
-    # Optional size of the linked resource in bytes, if known.
     size: Annotated[
         Optional[int],
         Field(description="Optional size of the linked resource in bytes, if known."),
     ] = None
-    # Optional display title for end-user UI.
     title: Annotated[Optional[str], Field(description="Optional display title for end-user UI.")] = None
-    # URI associated with this resource or media payload.
     uri: Annotated[str, Field(description="URI associated with this resource or media payload.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3364,21 +2417,14 @@ class ResourceLink(BaseModel):
 
 
 class EmbeddedResource(BaseModel):
-    # Optional annotations that help clients decide how to display or route this content.
     annotations: Annotated[
         Optional[Annotations],
         Field(description="Optional annotations that help clients decide how to display or route this content."),
     ] = None
-    # Embedded resource payload, either text or binary data.
     resource: Annotated[
         Union[TextResourceContents, BlobResourceContents],
         Field(description="Embedded resource payload, either text or binary data."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3394,7 +2440,6 @@ class EmbeddedResource(BaseModel):
 
 
 class PermissionOption(BaseModel):
-    # Unique identifier for this permission option.
     option_id: Annotated[
         str,
         Field(
@@ -3402,15 +2447,8 @@ class PermissionOption(BaseModel):
             description="Unique identifier for this permission option.",
         ),
     ]
-    # Human-readable label to display to the user.
     name: Annotated[str, Field(description="Human-readable label to display to the user.")]
-    # Hint about the nature of this permission option.
     kind: Annotated[PermissionOptionKind, Field(description="Hint about the nature of this permission option.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3421,30 +2459,17 @@ class PermissionOption(BaseModel):
 
 
 class CreateTerminalRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # The command to execute.
     command: Annotated[str, Field(description="The command to execute.")]
-    # Array of command arguments.
     args: Annotated[Optional[List[str]], Field(description="Array of command arguments.")] = None
-    # Environment variables for the command.
     env: Annotated[
         Optional[List[EnvVariable]],
         Field(description="Environment variables for the command."),
     ] = None
-    # Working directory for the command. Must be an absolute path.
     cwd: Annotated[
         Optional[str],
         Field(description="Working directory for the command. Must be an absolute path."),
     ] = None
-    # Maximum number of output bytes to retain.
-    #
-    # When the limit is exceeded, the Client truncates from the beginning of the output
-    # to stay within the limit.
-    #
-    # The Client MUST ensure truncation happens at a character boundary to maintain valid
-    # string output, even if this means the retained output is slightly less than the
-    # specified limit.
     output_byte_limit: Annotated[
         Optional[int],
         Field(
@@ -3453,11 +2478,6 @@ class CreateTerminalRequest(BaseModel):
             ge=0,
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3483,16 +2503,10 @@ class CreateTerminalRequest(BaseModel):
 
 
 class CreateUrlSessionElicitationRequest(ElicitationSessionScope):
-    # A human-readable message describing what input is needed.
     message: Annotated[
         str,
         Field(description="A human-readable message describing what input is needed."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3501,7 +2515,6 @@ class CreateUrlSessionElicitationRequest(ElicitationSessionScope):
         ),
     ] = None
     mode: Literal["url"]
-    # The unique identifier for this elicitation.
     elicitation_id: Annotated[
         str,
         Field(
@@ -3509,21 +2522,14 @@ class CreateUrlSessionElicitationRequest(ElicitationSessionScope):
             description="The unique identifier for this elicitation.",
         ),
     ]
-    # The URL to direct the user to.
     url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
 
 
 class CreateUrlRequestElicitationRequest(ElicitationRequestScope):
-    # A human-readable message describing what input is needed.
     message: Annotated[
         str,
         Field(description="A human-readable message describing what input is needed."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3532,7 +2538,6 @@ class CreateUrlRequestElicitationRequest(ElicitationRequestScope):
         ),
     ] = None
     mode: Literal["url"]
-    # The unique identifier for this elicitation.
     elicitation_id: Annotated[
         str,
         Field(
@@ -3540,7 +2545,6 @@ class CreateUrlRequestElicitationRequest(ElicitationRequestScope):
             description="The unique identifier for this elicitation.",
         ),
     ]
-    # The URL to direct the user to.
     url: Annotated[AnyUrl, Field(description="The URL to direct the user to.")]
 
 
@@ -3565,32 +2569,21 @@ class StringMultiSelectItems(_StringMultiSelectItems):
 
 
 class MultiSelectPropertySchema(BaseModel):
-    # Optional title for the property.
     title: Annotated[Optional[str], Field(description="Optional title for the property.")] = None
-    # Human-readable description.
     description: Annotated[Optional[str], Field(description="Human-readable description.")] = None
-    # Minimum number of items to select.
     min_items: Annotated[
         Optional[int],
         Field(alias="minItems", description="Minimum number of items to select.", ge=0),
     ] = None
-    # Maximum number of items to select.
     max_items: Annotated[
         Optional[int],
         Field(alias="maxItems", description="Maximum number of items to select.", ge=0),
     ] = None
-    # The items definition describing allowed values.
     items: Annotated[
         Union[StringMultiSelectItems, OtherMultiSelectItems, TitledMultiSelectItems],
         Field(description="The items definition describing allowed values."),
     ]
-    # Default selected values.
     default: Annotated[Optional[List[str]], Field(description="Default selected values.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3611,7 +2604,6 @@ class MultiSelectPropertySchema(BaseModel):
 
 
 class ConnectMcpRequest(BaseModel):
-    # The ACP MCP server ID that was provided by the component declaring the MCP server.
     server_id: Annotated[
         str,
         Field(
@@ -3619,11 +2611,6 @@ class ConnectMcpRequest(BaseModel):
             description="The ACP MCP server ID that was provided by the component declaring the MCP server.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3634,7 +2621,6 @@ class ConnectMcpRequest(BaseModel):
 
 
 class MessageMcpRequest(BaseModel):
-    # The MCP-over-ACP connection this message is sent on.
     connection_id: Annotated[
         str,
         Field(
@@ -3642,22 +2628,13 @@ class MessageMcpRequest(BaseModel):
             description="The MCP-over-ACP connection this message is sent on.",
         ),
     ]
-    # The inner MCP method name.
     method: Annotated[str, Field(description="The inner MCP method name.")]
-    # Optional inner MCP params.
-    #
-    # If omitted or set to `null`, the inner MCP message has no params.
     params: Annotated[
         Optional[Dict[str, Any]],
         Field(
             description="Optional inner MCP params.\n\nIf omitted or set to `null`, the inner MCP message has no params."
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3668,35 +2645,18 @@ class MessageMcpRequest(BaseModel):
 
 
 class SessionCapabilities(BaseModel):
-    # Whether the agent supports `session/list`.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports listing sessions.
     list: Annotated[
         Optional[SessionListCapabilities],
         Field(
             description="Whether the agent supports `session/list`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports listing sessions."
         ),
     ] = None
-    # Whether the agent supports `session/delete`.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports deleting sessions from `session/list`.
     delete: Annotated[
         Optional[SessionDeleteCapabilities],
         Field(
             description="Whether the agent supports `session/delete`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports deleting sessions from `session/list`."
         ),
     ] = None
-    # Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports `additionalDirectories` on
-    # supported session lifecycle requests.
-    #
-    # Agents that also support `session/list` may return
-    # `SessionInfo.additionalDirectories` to report the complete ordered
-    # additional-root list associated with a listed session.
     additional_directories: Annotated[
         Optional[SessionAdditionalDirectoriesCapabilities],
         Field(
@@ -3704,45 +2664,24 @@ class SessionCapabilities(BaseModel):
             description="Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports `additionalDirectories` on\nsupported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
         ),
     ] = None
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Whether the agent supports `session/fork`.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports forking sessions.
     fork: Annotated[
         Optional[SessionForkCapabilities],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports forking sessions."
         ),
     ] = None
-    # Whether the agent supports `session/resume`.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports resuming sessions.
     resume: Annotated[
         Optional[SessionResumeCapabilities],
         Field(
             description="Whether the agent supports `session/resume`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports resuming sessions."
         ),
     ] = None
-    # Whether the agent supports `session/close`.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports closing sessions.
     close: Annotated[
         Optional[SessionCloseCapabilities],
         Field(
             description="Whether the agent supports `session/close`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports closing sessions."
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3758,21 +2697,12 @@ class SessionCapabilities(BaseModel):
 
 
 class AgentAuthCapabilities(BaseModel):
-    # Whether the agent supports the logout method.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports the logout method.
     logout: Annotated[
         Optional[LogoutCapabilities],
         Field(
             description="Whether the agent supports the logout method.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports the logout method."
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3788,7 +2718,6 @@ class AgentAuthCapabilities(BaseModel):
 
 
 class NesDocumentDidChangeCapabilities(BaseModel):
-    # The sync kind the agent wants: `"full"` or `"incremental"`.
     sync_kind: Annotated[
         str,
         Field(
@@ -3796,11 +2725,6 @@ class NesDocumentDidChangeCapabilities(BaseModel):
             description='The sync kind the agent wants: `"full"` or `"incremental"`.',
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3811,7 +2735,6 @@ class NesDocumentDidChangeCapabilities(BaseModel):
 
 
 class NesContextCapabilities(BaseModel):
-    # Whether the agent wants recent files context.
     recent_files: Annotated[
         Optional[NesRecentFilesCapabilities],
         Field(
@@ -3819,7 +2742,6 @@ class NesContextCapabilities(BaseModel):
             description="Whether the agent wants recent files context.",
         ),
     ] = None
-    # Whether the agent wants related snippets context.
     related_snippets: Annotated[
         Optional[NesRelatedSnippetsCapabilities],
         Field(
@@ -3827,7 +2749,6 @@ class NesContextCapabilities(BaseModel):
             description="Whether the agent wants related snippets context.",
         ),
     ] = None
-    # Whether the agent wants edit history context.
     edit_history: Annotated[
         Optional[NesEditHistoryCapabilities],
         Field(
@@ -3835,7 +2756,6 @@ class NesContextCapabilities(BaseModel):
             description="Whether the agent wants edit history context.",
         ),
     ] = None
-    # Whether the agent wants user actions context.
     user_actions: Annotated[
         Optional[NesUserActionsCapabilities],
         Field(
@@ -3843,21 +2763,14 @@ class NesContextCapabilities(BaseModel):
             description="Whether the agent wants user actions context.",
         ),
     ] = None
-    # Whether the agent wants open files context.
     open_files: Annotated[
         Optional[NesOpenFilesCapabilities],
         Field(alias="openFiles", description="Whether the agent wants open files context."),
     ] = None
-    # Whether the agent wants diagnostics context.
     diagnostics: Annotated[
         Optional[NesDiagnosticsCapabilities],
         Field(description="Whether the agent wants diagnostics context."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3883,7 +2796,6 @@ class TerminalAuthMethod(AuthMethodTerminal):
 
 
 class ProviderInfo(BaseModel):
-    # Provider identifier, for example "main" or "openai".
     provider_id: Annotated[
         str,
         Field(
@@ -3891,7 +2803,6 @@ class ProviderInfo(BaseModel):
             description='Provider identifier, for example "main" or "openai".',
         ),
     ]
-    # Supported protocol types for this provider.
     supported: Annotated[
         List[
             Union[
@@ -3905,25 +2816,16 @@ class ProviderInfo(BaseModel):
         ],
         Field(description="Supported protocol types for this provider."),
     ]
-    # Whether this provider is mandatory and cannot be disabled via `providers/disable`.
-    # If true, clients must not call `providers/disable` for this provider ID.
     required: Annotated[
         bool,
         Field(
             description="Whether this provider is mandatory and cannot be disabled via `providers/disable`.\nIf true, clients must not call `providers/disable` for this provider ID."
         ),
     ]
-    # Current effective non-secret routing config.
-    # Null or omitted means provider is disabled.
     current: Annotated[
         Optional[ProviderCurrentConfig],
         Field(description="Current effective non-secret routing config.\nNull or omitted means provider is disabled."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3939,12 +2841,10 @@ class ProviderInfo(BaseModel):
 
 
 class SessionModeState(BaseModel):
-    # The current mode the Agent is in.
     current_mode_id: Annotated[
         str,
         Field(alias="currentModeId", description="The current mode the Agent is in."),
     ]
-    # The set of modes that the Agent can operate in
     available_modes: Annotated[
         List[SessionMode],
         Field(
@@ -3952,11 +2852,6 @@ class SessionModeState(BaseModel):
             description="The set of modes that the Agent can operate in",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -3972,16 +2867,12 @@ class SessionModeState(BaseModel):
 
 
 class SessionConfigOptionBoolean(SessionConfigBoolean):
-    # Unique identifier for the configuration option.
     id: Annotated[str, Field(description="Unique identifier for the configuration option.")]
-    # Human-readable label for the option.
     name: Annotated[str, Field(description="Human-readable label for the option.")]
-    # Optional description for the Client to display to the user.
     description: Annotated[
         Optional[str],
         Field(description="Optional description for the Client to display to the user."),
     ] = None
-    # Optional semantic category for this option (UX only).
     category: Annotated[
         Optional[
             Union[
@@ -3994,11 +2885,6 @@ class SessionConfigOptionBoolean(SessionConfigBoolean):
         ],
         Field(description="Optional semantic category for this option (UX only)."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4015,20 +2901,12 @@ class SessionConfigOptionBoolean(SessionConfigBoolean):
 
 
 class SessionConfigSelectGroup(BaseModel):
-    # Unique identifier for this group.
     group: Annotated[str, Field(description="Unique identifier for this group.")]
-    # Human-readable label for this group.
     name: Annotated[str, Field(description="Human-readable label for this group.")]
-    # The set of option values in this group.
     options: Annotated[
         List[SessionConfigSelectOption],
         Field(description="The set of option values in this group."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4044,10 +2922,7 @@ class SessionConfigSelectGroup(BaseModel):
 
 
 class ListSessionsResponse(BaseModel):
-    # Array of session information objects
     sessions: Annotated[List[SessionInfo], Field(description="Array of session information objects")]
-    # Opaque cursor token. If present, pass this in the next request's cursor parameter
-    # to fetch the next page. If absent, there are no more results.
     next_cursor: Annotated[
         Optional[str],
         Field(
@@ -4055,11 +2930,6 @@ class ListSessionsResponse(BaseModel):
             description="Opaque cursor token. If present, pass this in the next request's cursor parameter\nto fetch the next page. If absent, there are no more results.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4080,7 +2950,6 @@ class ListSessionsResponse(BaseModel):
 
 
 class PromptResponse(BaseModel):
-    # Indicates why the agent stopped processing the turn.
     stop_reason: Annotated[
         StopReason,
         Field(
@@ -4088,22 +2957,12 @@ class PromptResponse(BaseModel):
             description="Indicates why the agent stopped processing the turn.",
         ),
     ]
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Token usage for this turn (optional).
     usage: Annotated[
         Optional[Usage],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nToken usage for this turn (optional)."
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4131,15 +2990,8 @@ class NesSearchAndReplaceSuggestionVariant(NesSearchAndReplaceSuggestion):
 
 
 class Range(BaseModel):
-    # The start position (inclusive).
     start: Annotated[Position, Field(description="The start position (inclusive).")]
-    # The end position (exclusive).
     end: Annotated[Position, Field(description="The end position (exclusive).")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4150,8 +3002,6 @@ class Range(BaseModel):
 
 
 class Error(BaseModel):
-    # A number indicating the error type that occurred.
-    # This must be an integer as defined in the JSON-RPC specification.
     code: Annotated[
         Union[
             Literal[-32700],
@@ -4168,16 +3018,12 @@ class Error(BaseModel):
             description="A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
         ),
     ]
-    # A string providing a short description of the error.
-    # The message should be limited to a concise single sentence.
     message: Annotated[
         str,
         Field(
             description="A string providing a short description of the error.\nThe message should be limited to a concise single sentence."
         ),
     ]
-    # Optional primitive or structured value that contains additional information about the error.
-    # This may include debugging information or context-specific details.
     data: Annotated[
         Optional[Any],
         Field(
@@ -4208,26 +3054,17 @@ class UsageUpdate(_UsageUpdate):
 
 
 class PlanEntry(BaseModel):
-    # Human-readable description of what this task aims to accomplish.
     content: Annotated[
         str,
         Field(description="Human-readable description of what this task aims to accomplish."),
     ]
-    # The relative importance of this task.
-    # Used to indicate which tasks are most critical to the overall goal.
     priority: Annotated[
         PlanEntryPriority,
         Field(
             description="The relative importance of this task.\nUsed to indicate which tasks are most critical to the overall goal."
         ),
     ]
-    # Current execution status of this task.
     status: Annotated[PlanEntryStatus, Field(description="Current execution status of this task.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4238,21 +3075,12 @@ class PlanEntry(BaseModel):
 
 
 class Plan(BaseModel):
-    # The list of tasks to be accomplished.
-    #
-    # When updating a plan, the agent must send a complete list of all entries
-    # with their current status. The client replaces the entire plan with each update.
     entries: Annotated[
         List[PlanEntry],
         Field(
             description="The list of tasks to be accomplished.\n\nWhen updating a plan, the agent must send a complete list of all entries\nwith their current status. The client replaces the entire plan with each update."
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4276,23 +3104,13 @@ class PlanUpdateMarkdown(PlanMarkdown):
 
 
 class PlanItems(BaseModel):
-    # The plan ID to update.
     plan_id: Annotated[str, Field(alias="planId", description="The plan ID to update.")]
-    # The list of tasks to be accomplished.
-    #
-    # When updating an item-based plan, the agent must send a complete list of all entries
-    # with their current status. The client replaces that plan with each update.
     entries: Annotated[
         List[PlanEntry],
         Field(
             description="The list of tasks to be accomplished.\n\nWhen updating an item-based plan, the agent must send a complete list of all entries\nwith their current status. The client replaces that plan with each update."
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4308,7 +3126,6 @@ class PlanItems(BaseModel):
 
 
 class AvailableCommandInput(RootModel[UnstructuredCommandInput]):
-    # The input specification for a command.
     root: Annotated[
         UnstructuredCommandInput,
         Field(description="The input specification for a command."),
@@ -4316,23 +3133,12 @@ class AvailableCommandInput(RootModel[UnstructuredCommandInput]):
 
 
 class SessionConfigOptionsCapabilities(BaseModel):
-    # Whether the client supports boolean session configuration options.
-    #
-    # Optional. Omitted or `null` both mean the client does not advertise support.
-    # Supplying `{}` means agents may include `type: "boolean"` entries in
-    # `configOptions`, and the client may send `session/set_config_option`
-    # requests with `type: "boolean"` and a boolean `value`.
     boolean: Annotated[
         Optional[BooleanConfigOptionCapabilities],
         Field(
             description='Whether the client supports boolean session configuration options.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means agents may include `type: "boolean"` entries in\n`configOptions`, and the client may send `session/set_config_option`\nrequests with `type: "boolean"` and a boolean `value`.'
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4348,31 +3154,18 @@ class SessionConfigOptionsCapabilities(BaseModel):
 
 
 class ElicitationCapabilities(BaseModel):
-    # Whether the client supports form-based elicitation.
-    #
-    # Optional. Omitted or `null` both mean the client does not advertise support.
-    # Supplying `{}` means the client supports form-based elicitation.
     form: Annotated[
         Optional[ElicitationFormCapabilities],
         Field(
             description="Whether the client supports form-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports form-based elicitation."
         ),
     ] = None
-    # Whether the client supports URL-based elicitation.
-    #
-    # Optional. Omitted or `null` both mean the client does not advertise support.
-    # Supplying `{}` means the client supports URL-based elicitation.
     url: Annotated[
         Optional[ElicitationUrlCapabilities],
         Field(
             description="Whether the client supports URL-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports URL-based elicitation."
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4388,17 +3181,14 @@ class ElicitationCapabilities(BaseModel):
 
 
 class ClientNesCapabilities(BaseModel):
-    # Whether the client supports the `jump` suggestion kind.
     jump: Annotated[
         Optional[NesJumpCapabilities],
         Field(description="Whether the client supports the `jump` suggestion kind."),
     ] = None
-    # Whether the client supports the `rename` suggestion kind.
     rename: Annotated[
         Optional[NesRenameCapabilities],
         Field(description="Whether the client supports the `rename` suggestion kind."),
     ] = None
-    # Whether the client supports the `searchAndReplace` suggestion kind.
     search_and_replace: Annotated[
         Optional[NesSearchAndReplaceCapabilities],
         Field(
@@ -4406,11 +3196,6 @@ class ClientNesCapabilities(BaseModel):
             description="Whether the client supports the `searchAndReplace` suggestion kind.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4438,7 +3223,6 @@ class AcpMcpServer(McpServerAcp):
 
 
 class LoadSessionRequest(BaseModel):
-    # List of MCP servers to connect to for this session.
     mcp_servers: Annotated[
         List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]],
         Field(
@@ -4446,17 +3230,10 @@ class LoadSessionRequest(BaseModel):
             description="List of MCP servers to connect to for this session.",
         ),
     ]
-    # The working directory for this session. Must be an absolute path.
     cwd: Annotated[
         str,
         Field(description="The working directory for this session. Must be an absolute path."),
     ]
-    # Additional workspace roots to activate for this session. Each path must be absolute.
-    #
-    # When omitted or empty, no additional roots are activated. When non-empty,
-    # this is the complete resulting additional-root list for the loaded
-    # session. It may differ from any previously used or reported list as long as
-    # the request `cwd` matches the session's `cwd`.
     additional_directories: Annotated[
         Optional[List[str]],
         Field(
@@ -4464,13 +3241,7 @@ class LoadSessionRequest(BaseModel):
             description="Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
         ),
     ] = None
-    # The ID of the session to load.
     session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to load.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4491,18 +3262,11 @@ class LoadSessionRequest(BaseModel):
 
 
 class ForkSessionRequest(BaseModel):
-    # The ID of the session to fork.
     session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to fork.")]
-    # The working directory for this session. Must be an absolute path.
     cwd: Annotated[
         str,
         Field(description="The working directory for this session. Must be an absolute path."),
     ]
-    # Additional workspace roots to activate for this session. Each path must be absolute.
-    #
-    # When omitted or empty, no additional roots are activated. When non-empty,
-    # this is the complete resulting additional-root list for the forked
-    # session.
     additional_directories: Annotated[
         Optional[List[str]],
         Field(
@@ -4510,7 +3274,6 @@ class ForkSessionRequest(BaseModel):
             description="Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the forked\nsession.",
         ),
     ] = None
-    # List of MCP servers to connect to for this session.
     mcp_servers: Annotated[
         Optional[List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]]],
         Field(
@@ -4518,11 +3281,6 @@ class ForkSessionRequest(BaseModel):
             description="List of MCP servers to connect to for this session.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4543,19 +3301,11 @@ class ForkSessionRequest(BaseModel):
 
 
 class ResumeSessionRequest(BaseModel):
-    # The ID of the session to resume.
     session_id: Annotated[str, Field(alias="sessionId", description="The ID of the session to resume.")]
-    # The working directory for this session. Must be an absolute path.
     cwd: Annotated[
         str,
         Field(description="The working directory for this session. Must be an absolute path."),
     ]
-    # Additional workspace roots to activate for this session. Each path must be absolute.
-    #
-    # When omitted or empty, no additional roots are activated. When non-empty,
-    # this is the complete resulting additional-root list for the resumed
-    # session. It may differ from any previously used or reported list as long as
-    # the request `cwd` matches the session's `cwd`.
     additional_directories: Annotated[
         Optional[List[str]],
         Field(
@@ -4563,7 +3313,6 @@ class ResumeSessionRequest(BaseModel):
             description="Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
         ),
     ] = None
-    # List of MCP servers to connect to for this session.
     mcp_servers: Annotated[
         Optional[List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]]],
         Field(
@@ -4571,11 +3320,6 @@ class ResumeSessionRequest(BaseModel):
             description="List of MCP servers to connect to for this session.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4596,26 +3340,18 @@ class ResumeSessionRequest(BaseModel):
 
 
 class StartNesRequest(BaseModel):
-    # The root URI of the workspace.
     workspace_uri: Annotated[
         Optional[str],
         Field(alias="workspaceUri", description="The root URI of the workspace."),
     ] = None
-    # The workspace folders.
     workspace_folders: Annotated[
         Optional[List[WorkspaceFolder]],
         Field(alias="workspaceFolders", description="The workspace folders."),
     ] = None
-    # Repository metadata, if the workspace is a git repository.
     repository: Annotated[
         Optional[NesRepository],
         Field(description="Repository metadata, if the workspace is a git repository."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4631,15 +3367,8 @@ class StartNesRequest(BaseModel):
 
 
 class NesRelatedSnippet(BaseModel):
-    # The URI of the file containing the snippets.
     uri: Annotated[str, Field(description="The URI of the file containing the snippets.")]
-    # The code excerpts.
     excerpts: Annotated[List[NesExcerpt], Field(description="The code excerpts.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4650,16 +3379,12 @@ class NesRelatedSnippet(BaseModel):
 
 
 class NesOpenFile(BaseModel):
-    # The URI of the file.
     uri: Annotated[str, Field(description="The URI of the file.")]
-    # The language identifier.
     language_id: Annotated[str, Field(alias="languageId", description="The language identifier.")]
-    # The visible range in the editor, if any.
     visible_range: Annotated[
         Optional[Range],
         Field(alias="visibleRange", description="The visible range in the editor, if any."),
     ] = None
-    # Timestamp in milliseconds since epoch of when the file was last focused.
     last_focused_ms: Annotated[
         Optional[int],
         Field(
@@ -4668,11 +3393,6 @@ class NesOpenFile(BaseModel):
             ge=0,
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4688,19 +3408,10 @@ class NesOpenFile(BaseModel):
 
 
 class NesDiagnostic(BaseModel):
-    # The URI of the file containing the diagnostic.
     uri: Annotated[str, Field(description="The URI of the file containing the diagnostic.")]
-    # The range of the diagnostic.
     range: Annotated[Range, Field(description="The range of the diagnostic.")]
-    # The severity of the diagnostic.
     severity: Annotated[str, Field(description="The severity of the diagnostic.")]
-    # The diagnostic message.
     message: Annotated[str, Field(description="The diagnostic message.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4711,12 +3422,10 @@ class NesDiagnostic(BaseModel):
 
 
 class ClientErrorMessage(BaseModel):
-    # The id of the request this response answers.
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
     ]
-    # Method-specific error data.
     error: Annotated[Error, Field(description="Method-specific error data.")]
 
 
@@ -4725,20 +3434,12 @@ class AllowedOutcome(SelectedPermissionOutcome):
 
 
 class TerminalOutputResponse(BaseModel):
-    # The terminal output captured so far.
     output: Annotated[str, Field(description="The terminal output captured so far.")]
-    # Whether the output was truncated due to byte limits.
     truncated: Annotated[bool, Field(description="Whether the output was truncated due to byte limits.")]
-    # Exit status if the command has completed.
     exit_status: Annotated[
         Optional[TerminalExitStatus],
         Field(alias="exitStatus", description="Exit status if the command has completed."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4754,11 +3455,6 @@ class TerminalOutputResponse(BaseModel):
 
 
 class AcceptElicitationResponse(ElicitationAcceptAction):
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4770,21 +3466,14 @@ class AcceptElicitationResponse(ElicitationAcceptAction):
 
 
 class TextDocumentContentChangeEvent(BaseModel):
-    # The range of the document that changed. If `None`, the entire content is replaced.
     range: Annotated[
         Optional[Range],
         Field(description="The range of the document that changed. If `None`, the entire content is replaced."),
     ] = None
-    # The new text for the range, or the full document content if `range` is `None`.
     text: Annotated[
         str,
         Field(description="The new text for the range, or the full document content if `range` is `None`."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4795,18 +3484,13 @@ class TextDocumentContentChangeEvent(BaseModel):
 
 
 class DidFocusDocumentNotification(BaseModel):
-    # The session ID for this notification.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session ID for this notification."),
     ]
-    # The URI of the focused document.
     uri: Annotated[str, Field(description="The URI of the focused document.")]
-    # The version number of the document.
     version: Annotated[int, Field(description="The version number of the document.")]
-    # The current cursor position.
     position: Annotated[Position, Field(description="The current cursor position.")]
-    # The portion of the file currently visible in the editor viewport.
     visible_range: Annotated[
         Range,
         Field(
@@ -4814,11 +3498,6 @@ class DidFocusDocumentNotification(BaseModel):
             description="The portion of the file currently visible in the editor viewport.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4829,20 +3508,12 @@ class DidFocusDocumentNotification(BaseModel):
 
 
 class RejectNesNotification(BaseModel):
-    # The session ID for this notification.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session ID for this notification."),
     ]
-    # The ID of the rejected suggestion.
     id: Annotated[str, Field(description="The ID of the rejected suggestion.")]
-    # The reason for rejection.
     reason: Annotated[Optional[str], Field(description="The reason for rejection.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4878,18 +3549,12 @@ class EmbeddedResourceContentBlock(EmbeddedResource):
 
 
 class Content(BaseModel):
-    # The actual content block.
     content: Annotated[
         Union[
             TextContentBlock, ImageContentBlock, AudioContentBlock, ResourceContentBlock, EmbeddedResourceContentBlock
         ],
         Field(description="The actual content block.", discriminator="type"),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4904,17 +3569,14 @@ class ElicitationMultiSelectPropertySchema(MultiSelectPropertySchema):
 
 
 class AgentErrorMessage(BaseModel):
-    # The id of the request this response answers.
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
     ]
-    # Method-specific error data.
     error: Annotated[Error, Field(description="Method-specific error data.")]
 
 
 class NesDocumentEventCapabilities(BaseModel):
-    # Whether the agent wants `document/didOpen` events.
     did_open: Annotated[
         Optional[NesDocumentDidOpenCapabilities],
         Field(
@@ -4922,7 +3584,6 @@ class NesDocumentEventCapabilities(BaseModel):
             description="Whether the agent wants `document/didOpen` events.",
         ),
     ] = None
-    # Whether the agent wants `document/didChange` events, and the sync kind.
     did_change: Annotated[
         Optional[NesDocumentDidChangeCapabilities],
         Field(
@@ -4930,7 +3591,6 @@ class NesDocumentEventCapabilities(BaseModel):
             description="Whether the agent wants `document/didChange` events, and the sync kind.",
         ),
     ] = None
-    # Whether the agent wants `document/didClose` events.
     did_close: Annotated[
         Optional[NesDocumentDidCloseCapabilities],
         Field(
@@ -4938,7 +3598,6 @@ class NesDocumentEventCapabilities(BaseModel):
             description="Whether the agent wants `document/didClose` events.",
         ),
     ] = None
-    # Whether the agent wants `document/didSave` events.
     did_save: Annotated[
         Optional[NesDocumentDidSaveCapabilities],
         Field(
@@ -4946,7 +3605,6 @@ class NesDocumentEventCapabilities(BaseModel):
             description="Whether the agent wants `document/didSave` events.",
         ),
     ] = None
-    # Whether the agent wants `document/didFocus` events.
     did_focus: Annotated[
         Optional[NesDocumentDidFocusCapabilities],
         Field(
@@ -4954,11 +3612,6 @@ class NesDocumentEventCapabilities(BaseModel):
             description="Whether the agent wants `document/didFocus` events.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4974,16 +3627,10 @@ class NesDocumentEventCapabilities(BaseModel):
 
 
 class ListProvidersResponse(BaseModel):
-    # Configurable providers with current routing info suitable for UI display.
     providers: Annotated[
         List[ProviderInfo],
         Field(description="Configurable providers with current routing info suitable for UI display."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -4994,9 +3641,7 @@ class ListProvidersResponse(BaseModel):
 
 
 class SessionConfigSelect(BaseModel):
-    # The currently selected value.
     current_value: Annotated[str, Field(alias="currentValue", description="The currently selected value.")]
-    # The set of selectable options.
     options: Annotated[
         Union[List[SessionConfigSelectOption], List[SessionConfigSelectGroup]],
         Field(description="The set of selectable options."),
@@ -5004,15 +3649,8 @@ class SessionConfigSelect(BaseModel):
 
 
 class NesTextEdit(BaseModel):
-    # The range to replace.
     range: Annotated[Range, Field(description="The range to replace.")]
-    # The replacement text.
     new_text: Annotated[str, Field(alias="newText", description="The replacement text.")]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5023,13 +3661,9 @@ class NesTextEdit(BaseModel):
 
 
 class NesEditSuggestion(BaseModel):
-    # Unique identifier for accept/reject tracking.
     id: Annotated[str, Field(description="Unique identifier for accept/reject tracking.")]
-    # The URI of the file to edit.
     uri: Annotated[str, Field(description="The URI of the file to edit.")]
-    # The text edits to apply.
     edits: Annotated[List[NesTextEdit], Field(description="The text edits to apply.")]
-    # Optional suggested cursor position after applying edits.
     cursor_position: Annotated[
         Optional[Position],
         Field(
@@ -5037,11 +3671,6 @@ class NesEditSuggestion(BaseModel):
             description="Optional suggested cursor position after applying edits.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5061,17 +3690,12 @@ class AgentPlanUpdate(Plan):
 
 
 class ContentChunk(BaseModel):
-    # A single item of content
     content: Annotated[
         Union[
             TextContentBlock, ImageContentBlock, AudioContentBlock, ResourceContentBlock, EmbeddedResourceContentBlock
         ],
         Field(description="A single item of content", discriminator="type"),
     ]
-    # A unique identifier for the message this chunk belongs to.
-    #
-    # All chunks belonging to the same message share the same `messageId`.
-    # A change in `messageId` indicates a new message has started.
     message_id: Annotated[
         Optional[str],
         Field(
@@ -5079,11 +3703,6 @@ class ContentChunk(BaseModel):
             description="A unique identifier for the message this chunk belongs to.\n\nAll chunks belonging to the same message share the same `messageId`.\nA change in `messageId` indicates a new message has started.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5103,16 +3722,10 @@ class PlanUpdateItems(PlanItems):
 
 
 class PlanUpdate(BaseModel):
-    # The updated plan content.
     plan: Annotated[
         Union[PlanUpdateItems, PlanUpdateFile, PlanUpdateMarkdown],
         Field(description="The updated plan content.", discriminator="type"),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5123,23 +3736,15 @@ class PlanUpdate(BaseModel):
 
 
 class AvailableCommand(BaseModel):
-    # Command name (e.g., `create_plan`, `research_codebase`).
     name: Annotated[
         str,
         Field(description="Command name (e.g., `create_plan`, `research_codebase`)."),
     ]
-    # Human-readable description of what the command does.
     description: Annotated[str, Field(description="Human-readable description of what the command does.")]
-    # Input for the command if required
     input: Annotated[
         Optional[AvailableCommandInput],
         Field(description="Input for the command if required"),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5155,16 +3760,10 @@ class AvailableCommand(BaseModel):
 
 
 class _AvailableCommandsUpdate(BaseModel):
-    # Commands the agent can execute
     available_commands: Annotated[
         List[AvailableCommand],
         Field(alias="availableCommands", description="Commands the agent can execute"),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5180,10 +3779,6 @@ class _AvailableCommandsUpdate(BaseModel):
 
 
 class ClientSessionCapabilities(BaseModel):
-    # Config option capabilities supported by the client.
-    #
-    # Omitted or `null` both mean the client does not advertise support for any
-    # config option extensions.
     config_options: Annotated[
         Optional[SessionConfigOptionsCapabilities],
         Field(
@@ -5191,11 +3786,6 @@ class ClientSessionCapabilities(BaseModel):
             description="Config option capabilities supported by the client.\n\nOmitted or `null` both mean the client does not advertise support for any\nconfig option extensions.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5211,16 +3801,10 @@ class ClientSessionCapabilities(BaseModel):
 
 
 class NewSessionRequest(BaseModel):
-    # The working directory for this session. Must be an absolute path.
     cwd: Annotated[
         str,
         Field(description="The working directory for this session. Must be an absolute path."),
     ]
-    # Additional workspace roots for this session. Each path must be absolute.
-    #
-    # These expand the session's filesystem scope without changing `cwd`, which
-    # remains the base for relative paths. When omitted or empty, no
-    # additional roots are activated for the new session.
     additional_directories: Annotated[
         Optional[List[str]],
         Field(
@@ -5228,7 +3812,6 @@ class NewSessionRequest(BaseModel):
             description="Additional workspace roots for this session. Each path must be absolute.\n\nThese expand the session's filesystem scope without changing `cwd`, which\nremains the base for relative paths. When omitted or empty, no\nadditional roots are activated for the new session.",
         ),
     ] = None
-    # List of MCP (Model Context Protocol) servers the agent should connect to.
     mcp_servers: Annotated[
         List[Union[HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio]],
         Field(
@@ -5236,11 +3819,6 @@ class NewSessionRequest(BaseModel):
             description="List of MCP (Model Context Protocol) servers the agent should connect to.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5261,7 +3839,6 @@ class NewSessionRequest(BaseModel):
 
 
 class PromptRequest(BaseModel):
-    # The ID of the session to send this user message to
     session_id: Annotated[
         str,
         Field(
@@ -5269,19 +3846,6 @@ class PromptRequest(BaseModel):
             description="The ID of the session to send this user message to",
         ),
     ]
-    # The blocks of content that compose the user's message.
-    #
-    # As a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],
-    # while other variants are optionally enabled via [`PromptCapabilities`].
-    #
-    # The Client MUST adapt its interface according to [`PromptCapabilities`].
-    #
-    # The client MAY include referenced pieces of context as either
-    # [`ContentBlock::Resource`] or [`ContentBlock::ResourceLink`].
-    #
-    # When available, [`ContentBlock::Resource`] is preferred
-    # as it avoids extra round-trips and allows the message to include
-    # pieces of context from sources the agent may not have access to.
     prompt: Annotated[
         List[
             Annotated[
@@ -5299,11 +3863,6 @@ class PromptRequest(BaseModel):
             description="The blocks of content that compose the user's message.\n\nAs a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],\nwhile other variants are optionally enabled via [`PromptCapabilities`].\n\nThe Client MUST adapt its interface according to [`PromptCapabilities`].\n\nThe client MAY include referenced pieces of context as either\n[`ContentBlock::Resource`] or [`ContentBlock::ResourceLink`].\n\nWhen available, [`ContentBlock::Resource`] is preferred\nas it avoids extra round-trips and allows the message to include\npieces of context from sources the agent may not have access to."
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5314,22 +3873,18 @@ class PromptRequest(BaseModel):
 
 
 class NesSuggestContext(BaseModel):
-    # Recently accessed files.
     recent_files: Annotated[
         Optional[List[NesRecentFile]],
         Field(alias="recentFiles", description="Recently accessed files."),
     ] = None
-    # Related code snippets.
     related_snippets: Annotated[
         Optional[List[NesRelatedSnippet]],
         Field(alias="relatedSnippets", description="Related code snippets."),
     ] = None
-    # Recent edit history.
     edit_history: Annotated[
         Optional[List[NesEditHistoryEntry]],
         Field(alias="editHistory", description="Recent edit history."),
     ] = None
-    # Recent user actions (typing, navigation, etc.).
     user_actions: Annotated[
         Optional[List[NesUserAction]],
         Field(
@@ -5337,21 +3892,14 @@ class NesSuggestContext(BaseModel):
             description="Recent user actions (typing, navigation, etc.).",
         ),
     ] = None
-    # Currently open files in the editor.
     open_files: Annotated[
         Optional[List[NesOpenFile]],
         Field(alias="openFiles", description="Currently open files in the editor."),
     ] = None
-    # Current diagnostics (errors, warnings).
     diagnostics: Annotated[
         Optional[List[NesDiagnostic]],
         Field(description="Current diagnostics (errors, warnings)."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5362,7 +3910,6 @@ class NesSuggestContext(BaseModel):
 
 
 class RequestPermissionResponse(BaseModel):
-    # The user's decision on the permission request.
     outcome: Annotated[
         Union[DeniedOutcome, AllowedOutcome],
         Field(
@@ -5370,11 +3917,6 @@ class RequestPermissionResponse(BaseModel):
             discriminator="outcome",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5385,25 +3927,16 @@ class RequestPermissionResponse(BaseModel):
 
 
 class DidChangeDocumentNotification(BaseModel):
-    # The session ID for this notification.
     session_id: Annotated[
         str,
         Field(alias="sessionId", description="The session ID for this notification."),
     ]
-    # The URI of the changed document.
     uri: Annotated[str, Field(description="The URI of the changed document.")]
-    # The new version number of the document.
     version: Annotated[int, Field(description="The new version number of the document.")]
-    # The content changes.
     content_changes: Annotated[
         List[TextDocumentContentChangeEvent],
         Field(alias="contentChanges", description="The content changes."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5423,11 +3956,8 @@ class ContentToolCallContent(Content):
 
 
 class ElicitationSchema(BaseModel):
-    # Type discriminator. Always `"object"`.
     type: Annotated[Optional[str], Field(description='Type discriminator. Always `"object"`.')] = "object"
-    # Optional title for the schema.
     title: Annotated[Optional[str], Field(description="Optional title for the schema.")] = None
-    # Property definitions (must be primitive types).
     properties: Annotated[
         Optional[
             Dict[
@@ -5447,18 +3977,11 @@ class ElicitationSchema(BaseModel):
             validate_default=True,
         ),
     ] = {}
-    # List of required property names.
     required: Annotated[Optional[List[str]], Field(description="List of required property names.")] = None
-    # Optional description of what this schema represents.
     description: Annotated[
         Optional[str],
         Field(description="Optional description of what this schema represents."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5479,7 +4002,6 @@ class ElicitationSchema(BaseModel):
 
 
 class ElicitationFormSessionMode(ElicitationSessionScope):
-    # A JSON Schema describing the form fields to present to the user.
     requested_schema: Annotated[
         ElicitationSchema,
         Field(
@@ -5490,7 +4012,6 @@ class ElicitationFormSessionMode(ElicitationSessionScope):
 
 
 class ElicitationFormRequestMode(ElicitationRequestScope):
-    # A JSON Schema describing the form fields to present to the user.
     requested_schema: Annotated[
         ElicitationSchema,
         Field(
@@ -5501,11 +4022,6 @@ class ElicitationFormRequestMode(ElicitationRequestScope):
 
 
 class ElicitationFormMode(RootModel[Union[ElicitationFormSessionMode, ElicitationFormRequestMode]]):
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Form-based elicitation mode where the client renders a form from the provided schema.
     root: Annotated[
         Union[ElicitationFormSessionMode, ElicitationFormRequestMode],
         Field(
@@ -5515,16 +4031,10 @@ class ElicitationFormMode(RootModel[Union[ElicitationFormSessionMode, Elicitatio
 
 
 class NesEventCapabilities(BaseModel):
-    # Document event capabilities.
     document: Annotated[
         Optional[NesDocumentEventCapabilities],
         Field(description="Document event capabilities."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5540,16 +4050,12 @@ class NesEventCapabilities(BaseModel):
 
 
 class SessionConfigOptionSelect(SessionConfigSelect):
-    # Unique identifier for the configuration option.
     id: Annotated[str, Field(description="Unique identifier for the configuration option.")]
-    # Human-readable label for the option.
     name: Annotated[str, Field(description="Human-readable label for the option.")]
-    # Optional description for the Client to display to the user.
     description: Annotated[
         Optional[str],
         Field(description="Optional description for the Client to display to the user."),
     ] = None
-    # Optional semantic category for this option (UX only).
     category: Annotated[
         Optional[
             Union[
@@ -5562,11 +4068,6 @@ class SessionConfigOptionSelect(SessionConfigSelect):
         ],
         Field(description="Optional semantic category for this option (UX only)."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5583,16 +4084,12 @@ class SessionConfigOptionSelect(SessionConfigSelect):
 
 
 class LoadSessionResponse(BaseModel):
-    # Initial mode state if supported by the Agent
-    #
-    # See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     modes: Annotated[
         Optional[SessionModeState],
         Field(
             description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
         ),
     ] = None
-    # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
         Optional[
             List[
@@ -5607,11 +4104,6 @@ class LoadSessionResponse(BaseModel):
             description="Initial session configuration options if supported by the Agent.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5632,7 +4124,6 @@ class LoadSessionResponse(BaseModel):
 
 
 class ForkSessionResponse(BaseModel):
-    # Unique identifier for the newly created forked session.
     session_id: Annotated[
         str,
         Field(
@@ -5640,16 +4131,12 @@ class ForkSessionResponse(BaseModel):
             description="Unique identifier for the newly created forked session.",
         ),
     ]
-    # Initial mode state if supported by the Agent
-    #
-    # See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     modes: Annotated[
         Optional[SessionModeState],
         Field(
             description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
         ),
     ] = None
-    # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
         Optional[
             List[
@@ -5664,11 +4151,6 @@ class ForkSessionResponse(BaseModel):
             description="Initial session configuration options if supported by the Agent.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5689,16 +4171,12 @@ class ForkSessionResponse(BaseModel):
 
 
 class ResumeSessionResponse(BaseModel):
-    # Initial mode state if supported by the Agent
-    #
-    # See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     modes: Annotated[
         Optional[SessionModeState],
         Field(
             description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
         ),
     ] = None
-    # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
         Optional[
             List[
@@ -5713,11 +4191,6 @@ class ResumeSessionResponse(BaseModel):
             description="Initial session configuration options if supported by the Agent.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5738,7 +4211,6 @@ class ResumeSessionResponse(BaseModel):
 
 
 class SetSessionConfigOptionResponse(BaseModel):
-    # The full set of configuration options and their current values.
     config_options: Annotated[
         List[
             Annotated[
@@ -5751,11 +4223,6 @@ class SetSessionConfigOptionResponse(BaseModel):
             description="The full set of configuration options and their current values.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5795,7 +4262,6 @@ class AvailableCommandsUpdate(_AvailableCommandsUpdate):
 
 
 class ToolCall(BaseModel):
-    # Unique identifier for this tool call within the session.
     tool_call_id: Annotated[
         str,
         Field(
@@ -5803,22 +4269,17 @@ class ToolCall(BaseModel):
             description="Unique identifier for this tool call within the session.",
         ),
     ]
-    # Human-readable title describing what the tool is doing.
     title: Annotated[
         str,
         Field(description="Human-readable title describing what the tool is doing."),
     ]
-    # The category of tool being invoked.
-    # Helps clients choose appropriate icons and UI treatment.
     kind: Annotated[
         Optional[ToolKind],
         Field(
             description="The category of tool being invoked.\nHelps clients choose appropriate icons and UI treatment."
         ),
     ] = None
-    # Current execution status of the tool call.
     status: Annotated[Optional[ToolCallStatus], Field(description="Current execution status of the tool call.")] = None
-    # Content produced by the tool call.
     content: Annotated[
         Optional[
             List[
@@ -5830,27 +4291,18 @@ class ToolCall(BaseModel):
         ],
         Field(description="Content produced by the tool call."),
     ] = None
-    # File locations affected by this tool call.
-    # Enables "follow-along" features in clients.
     locations: Annotated[
         Optional[List[ToolCallLocation]],
         Field(description='File locations affected by this tool call.\nEnables "follow-along" features in clients.'),
     ] = None
-    # Raw input parameters sent to the tool.
     raw_input: Annotated[
         Optional[Any],
         Field(alias="rawInput", description="Raw input parameters sent to the tool."),
     ] = None
-    # Raw output returned by the tool.
     raw_output: Annotated[
         Optional[Any],
         Field(alias="rawOutput", description="Raw output returned by the tool."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5876,7 +4328,6 @@ class ToolCall(BaseModel):
 
 
 class _ConfigOptionUpdate(BaseModel):
-    # The full set of configuration options and their current values.
     config_options: Annotated[
         List[
             Annotated[
@@ -5889,11 +4340,6 @@ class _ConfigOptionUpdate(BaseModel):
             description="The full set of configuration options and their current values.",
         ),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -5909,8 +4355,6 @@ class _ConfigOptionUpdate(BaseModel):
 
 
 class ClientCapabilities(BaseModel):
-    # File system capabilities supported by the client.
-    # Determines which file operations the agent can request.
     fs: Annotated[
         Optional[FileSystemCapabilities],
         Field(
@@ -5918,42 +4362,22 @@ class ClientCapabilities(BaseModel):
             validate_default=True,
         ),
     ] = FileSystemCapabilities()
-    # Whether the Client support all `terminal/*` methods.
     terminal: Annotated[
         Optional[bool],
         Field(description="Whether the Client support all `terminal/*` methods."),
     ] = False
-    # Session-related capabilities supported by the client.
-    #
-    # Optional. Omitted or `null` both mean the client does not advertise any
-    # session-related extensions.
     session: Annotated[
         Optional[ClientSessionCapabilities],
         Field(
             description="Session-related capabilities supported by the client.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nsession-related extensions."
         ),
     ] = None
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Whether the client supports `plan_update` and `plan_removed` session updates.
-    #
-    # Optional. Omitted or `null` both mean the client does not advertise support.
-    # Supplying `{}` means the client can receive both update types.
     plan: Annotated[
         Optional[PlanCapabilities],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the client supports `plan_update` and `plan_removed` session updates.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client can receive both update types."
         ),
     ] = None
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Authentication capabilities supported by the client.
-    # Determines which authentication method types the agent may include
-    # in its `InitializeResponse`.
     auth: Annotated[
         Optional[AuthCapabilities],
         Field(
@@ -5961,40 +4385,18 @@ class ClientCapabilities(BaseModel):
             validate_default=True,
         ),
     ] = {"terminal": False}
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Elicitation capabilities supported by the client.
-    # Determines which elicitation modes the agent may use.
-    #
-    # Optional. Omitted or `null` both mean the client does not advertise
-    # elicitation support.
     elicitation: Annotated[
         Optional[ElicitationCapabilities],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.\n\nOptional. Omitted or `null` both mean the client does not advertise\nelicitation support."
         ),
     ] = None
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # NES (Next Edit Suggestions) capabilities supported by the client.
-    #
-    # Optional. Omitted or `null` both mean the client does not advertise any
-    # NES suggestion-kind extensions.
     nes: Annotated[
         Optional[ClientNesCapabilities],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nNES suggestion-kind extensions."
         ),
     ] = None
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # The position encodings supported by the client, in order of preference.
     position_encodings: Annotated[
         Optional[List[str]],
         Field(
@@ -6002,11 +4404,6 @@ class ClientCapabilities(BaseModel):
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encodings supported by the client, in order of preference.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6042,31 +4439,19 @@ class ClientCapabilities(BaseModel):
 
 
 class SuggestNesRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # The URI of the document to suggest for.
     uri: Annotated[str, Field(description="The URI of the document to suggest for.")]
-    # The version number of the document.
     version: Annotated[int, Field(description="The version number of the document.")]
-    # The current cursor position.
     position: Annotated[Position, Field(description="The current cursor position.")]
-    # The current text selection range, if any.
     selection: Annotated[Optional[Range], Field(description="The current text selection range, if any.")] = None
-    # What triggered this suggestion request.
     trigger_kind: Annotated[
         str,
         Field(alias="triggerKind", description="What triggered this suggestion request."),
     ]
-    # Context for the suggestion, included based on agent capabilities.
     context: Annotated[
         Optional[NesSuggestContext],
         Field(description="Context for the suggestion, included based on agent capabilities."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6077,12 +4462,10 @@ class SuggestNesRequest(BaseModel):
 
 
 class ClientResponseMessage(BaseModel):
-    # The id of the request this response answers.
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
     ]
-    # Method-specific response data.
     result: Annotated[
         Union[
             WriteTextFileResponse,
@@ -6108,7 +4491,6 @@ class ClientResponseMessage(BaseModel):
 
 
 class ClientResponse(RootModel[Union[ClientResponseMessage, ClientErrorMessage]]):
-    # A JSON-RPC response object.
     root: Annotated[
         Union[ClientResponseMessage, ClientErrorMessage],
         Field(description="A JSON-RPC response object."),
@@ -6116,9 +4498,7 @@ class ClientResponse(RootModel[Union[ClientResponseMessage, ClientErrorMessage]]
 
 
 class ClientNotification(BaseModel):
-    # The notification method name.
     method: Annotated[str, Field(description="The notification method name.")]
-    # Method-specific notification parameters.
     params: Annotated[
         Optional[
             Union[
@@ -6139,18 +4519,13 @@ class ClientNotification(BaseModel):
 
 
 class ToolCallUpdate(BaseModel):
-    # The ID of the tool call being updated.
     tool_call_id: Annotated[
         str,
         Field(alias="toolCallId", description="The ID of the tool call being updated."),
     ]
-    # Update the tool kind.
     kind: Annotated[Optional[ToolKind], Field(description="Update the tool kind.")] = None
-    # Update the execution status.
     status: Annotated[Optional[ToolCallStatus], Field(description="Update the execution status.")] = None
-    # Update the human-readable title.
     title: Annotated[Optional[str], Field(description="Update the human-readable title.")] = None
-    # Replace the content collection.
     content: Annotated[
         Optional[
             List[
@@ -6162,20 +4537,12 @@ class ToolCallUpdate(BaseModel):
         ],
         Field(description="Replace the content collection."),
     ] = None
-    # Replace the locations collection.
     locations: Annotated[
         Optional[List[ToolCallLocation]],
         Field(description="Replace the locations collection."),
     ] = None
-    # Update the raw input.
     raw_input: Annotated[Optional[Any], Field(alias="rawInput", description="Update the raw input.")] = None
-    # Update the raw output.
     raw_output: Annotated[Optional[Any], Field(alias="rawOutput", description="Update the raw output.")] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6201,16 +4568,10 @@ class ToolCallUpdate(BaseModel):
 
 
 class CreateFormSessionElicitationRequest(ElicitationSessionScope):
-    # A human-readable message describing what input is needed.
     message: Annotated[
         str,
         Field(description="A human-readable message describing what input is needed."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6219,7 +4580,6 @@ class CreateFormSessionElicitationRequest(ElicitationSessionScope):
         ),
     ] = None
     mode: Literal["form"]
-    # A JSON Schema describing the form fields to present to the user.
     requested_schema: Annotated[
         ElicitationSchema,
         Field(
@@ -6230,16 +4590,10 @@ class CreateFormSessionElicitationRequest(ElicitationSessionScope):
 
 
 class CreateFormRequestElicitationRequest(ElicitationRequestScope):
-    # A human-readable message describing what input is needed.
     message: Annotated[
         str,
         Field(description="A human-readable message describing what input is needed."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6248,7 +4602,6 @@ class CreateFormRequestElicitationRequest(ElicitationRequestScope):
         ),
     ] = None
     mode: Literal["form"]
-    # A JSON Schema describing the form fields to present to the user.
     requested_schema: Annotated[
         ElicitationSchema,
         Field(
@@ -6286,21 +4639,14 @@ CreateElicitationResponse = Union[
 
 
 class NesCapabilities(BaseModel):
-    # Events the agent wants to receive.
     events: Annotated[
         Optional[NesEventCapabilities],
         Field(description="Events the agent wants to receive."),
     ] = None
-    # Context the agent wants attached to each suggestion request.
     context: Annotated[
         Optional[NesContextCapabilities],
         Field(description="Context the agent wants attached to each suggestion request."),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6316,9 +4662,6 @@ class NesCapabilities(BaseModel):
 
 
 class NewSessionResponse(BaseModel):
-    # Unique identifier for the created session.
-    #
-    # Used in all subsequent requests for this conversation.
     session_id: Annotated[
         str,
         Field(
@@ -6326,16 +4669,12 @@ class NewSessionResponse(BaseModel):
             description="Unique identifier for the created session.\n\nUsed in all subsequent requests for this conversation.",
         ),
     ]
-    # Initial mode state if supported by the Agent
-    #
-    # See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     modes: Annotated[
         Optional[SessionModeState],
         Field(
             description="Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
         ),
     ] = None
-    # Initial session configuration options if supported by the Agent.
     config_options: Annotated[
         Optional[
             List[
@@ -6350,11 +4689,6 @@ class NewSessionResponse(BaseModel):
             description="Initial session configuration options if supported by the Agent.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6375,7 +4709,6 @@ class NewSessionResponse(BaseModel):
 
 
 class SuggestNesResponse(BaseModel):
-    # The list of suggestions.
     suggestions: Annotated[
         List[
             Annotated[
@@ -6390,11 +4723,6 @@ class SuggestNesResponse(BaseModel):
         ],
         Field(description="The list of suggestions."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6417,7 +4745,6 @@ class ConfigOptionUpdate(_ConfigOptionUpdate):
 
 
 class InitializeRequest(BaseModel):
-    # The latest protocol version supported by the client.
     protocol_version: Annotated[
         int,
         Field(
@@ -6427,7 +4754,6 @@ class InitializeRequest(BaseModel):
             le=65535,
         ),
     ]
-    # Capabilities supported by the client.
     client_capabilities: Annotated[
         Optional[ClientCapabilities],
         Field(
@@ -6436,9 +4762,6 @@ class InitializeRequest(BaseModel):
             validate_default=True,
         ),
     ] = ClientCapabilities()
-    # Information about the Client name and version sent to the Agent.
-    #
-    # Note: in future versions of the protocol, this will be required.
     client_info: Annotated[
         Optional[Implementation],
         Field(
@@ -6446,11 +4769,6 @@ class InitializeRequest(BaseModel):
             description="Information about the Client name and version sent to the Agent.\n\nNote: in future versions of the protocol, this will be required.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6493,9 +4811,7 @@ class InitializeRequest(BaseModel):
 
 
 class RequestPermissionRequest(BaseModel):
-    # The session ID for this request.
     session_id: Annotated[str, Field(alias="sessionId", description="The session ID for this request.")]
-    # Details about the tool call requiring permission.
     tool_call: Annotated[
         ToolCallUpdate,
         Field(
@@ -6503,16 +4819,10 @@ class RequestPermissionRequest(BaseModel):
             description="Details about the tool call requiring permission.",
         ),
     ]
-    # Available permission options for the user to choose from.
     options: Annotated[
         List[PermissionOption],
         Field(description="Available permission options for the user to choose from."),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6523,7 +4833,6 @@ class RequestPermissionRequest(BaseModel):
 
 
 class AgentCapabilities(BaseModel):
-    # Whether the agent supports `session/load`.
     load_session: Annotated[
         Optional[bool],
         Field(
@@ -6531,7 +4840,6 @@ class AgentCapabilities(BaseModel):
             description="Whether the agent supports `session/load`.",
         ),
     ] = False
-    # Prompt capabilities supported by the agent.
     prompt_capabilities: Annotated[
         Optional[PromptCapabilities],
         Field(
@@ -6540,7 +4848,6 @@ class AgentCapabilities(BaseModel):
             validate_default=True,
         ),
     ] = PromptCapabilities()
-    # MCP capabilities supported by the agent.
     mcp_capabilities: Annotated[
         Optional[McpCapabilities],
         Field(
@@ -6549,7 +4856,6 @@ class AgentCapabilities(BaseModel):
             validate_default=True,
         ),
     ] = McpCapabilities()
-    # Session lifecycle and prompt capabilities advertised by the agent.
     session_capabilities: Annotated[
         Optional[SessionCapabilities],
         Field(
@@ -6558,7 +4864,6 @@ class AgentCapabilities(BaseModel):
             validate_default=True,
         ),
     ] = SessionCapabilities()
-    # Authentication-related capabilities supported by the agent.
     auth: Annotated[
         Optional[AgentAuthCapabilities],
         Field(
@@ -6566,39 +4871,18 @@ class AgentCapabilities(BaseModel):
             validate_default=True,
         ),
     ] = {}
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # Provider configuration capabilities supported by the agent.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support.
-    # Supplying `{}` means the agent supports provider configuration methods.
     providers: Annotated[
         Optional[ProvidersCapabilities],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports provider configuration methods."
         ),
     ] = None
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # NES (Next Edit Suggestions) capabilities supported by the agent.
-    #
-    # Optional. Omitted or `null` both mean the agent does not advertise support
-    # for NES methods.
     nes: Annotated[
         Optional[NesCapabilities],
         Field(
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support\nfor NES methods."
         ),
     ] = None
-    # **UNSTABLE**
-    #
-    # This capability is not part of the spec yet, and may be removed or changed at any point.
-    #
-    # The position encoding selected by the agent from the client's supported encodings.
     position_encoding: Annotated[
         Optional[str],
         Field(
@@ -6606,11 +4890,6 @@ class AgentCapabilities(BaseModel):
             description="**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encoding selected by the agent from the client's supported encodings.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6646,7 +4925,6 @@ class AgentCapabilities(BaseModel):
 
 
 class SessionNotification(BaseModel):
-    # The ID of the session this update pertains to.
     session_id: Annotated[
         str,
         Field(
@@ -6654,7 +4932,6 @@ class SessionNotification(BaseModel):
             description="The ID of the session this update pertains to.",
         ),
     ]
-    # The actual update content.
     update: Annotated[
         Union[
             UserMessageChunk,
@@ -6673,11 +4950,6 @@ class SessionNotification(BaseModel):
         ],
         Field(description="The actual update content.", discriminator="session_update"),
     ]
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6688,14 +4960,11 @@ class SessionNotification(BaseModel):
 
 
 class ClientRequest(BaseModel):
-    # The request id used to correlate the matching response.
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The request id used to correlate the matching response."),
     ]
-    # The method name to invoke.
     method: Annotated[str, Field(description="The method name to invoke.")]
-    # Method-specific request parameters.
     params: Annotated[
         Optional[
             Union[
@@ -6727,14 +4996,11 @@ class ClientRequest(BaseModel):
 
 
 class AgentRequest(BaseModel):
-    # The request id used to correlate the matching response.
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The request id used to correlate the matching response."),
     ]
-    # The method name to invoke.
     method: Annotated[str, Field(description="The method name to invoke.")]
-    # Method-specific request parameters.
     params: Annotated[
         Optional[
             Union[
@@ -6764,10 +5030,6 @@ class AgentRequest(BaseModel):
 
 
 class InitializeResponse(BaseModel):
-    # The protocol version the client specified if supported by the agent,
-    # or the latest protocol version supported by the agent.
-    #
-    # The client should disconnect, if it doesn't support this version.
     protocol_version: Annotated[
         int,
         Field(
@@ -6777,7 +5039,6 @@ class InitializeResponse(BaseModel):
             le=65535,
         ),
     ]
-    # Capabilities supported by the agent.
     agent_capabilities: Annotated[
         Optional[AgentCapabilities],
         Field(
@@ -6786,7 +5047,6 @@ class InitializeResponse(BaseModel):
             validate_default=True,
         ),
     ] = AgentCapabilities()
-    # Authentication methods supported by the agent.
     auth_methods: Annotated[
         Optional[List[Union[EnvVarAuthMethod, TerminalAuthMethod, AuthMethodAgent]]],
         Field(
@@ -6795,9 +5055,6 @@ class InitializeResponse(BaseModel):
             validate_default=True,
         ),
     ] = []
-    # Information about the Agent name and version sent to the Client.
-    #
-    # Note: in future versions of the protocol, this will be required.
     agent_info: Annotated[
         Optional[Implementation],
         Field(
@@ -6805,11 +5062,6 @@ class InitializeResponse(BaseModel):
             description="Information about the Agent name and version sent to the Client.\n\nNote: in future versions of the protocol, this will be required.",
         ),
     ] = None
-    # The _meta property is reserved by ACP to allow clients and agents to attach additional
-    # metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    # these keys.
-    #
-    # See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     field_meta: Annotated[
         Optional[Dict[str, Any]],
         Field(
@@ -6845,9 +5097,7 @@ class InitializeResponse(BaseModel):
 
 
 class AgentNotification(BaseModel):
-    # The notification method name.
     method: Annotated[str, Field(description="The notification method name.")]
-    # Method-specific notification parameters.
     params: Annotated[
         Optional[
             Union[
@@ -6862,12 +5112,10 @@ class AgentNotification(BaseModel):
 
 
 class AgentResponseMessage(BaseModel):
-    # The id of the request this response answers.
     id: Annotated[
         Optional[Union[int, str]],
         Field(description="The id of the request this response answers."),
     ]
-    # Method-specific response data.
     result: Annotated[
         Union[
             InitializeResponse,
@@ -6896,7 +5144,6 @@ class AgentResponseMessage(BaseModel):
 
 
 class AgentResponse(RootModel[Union[AgentResponseMessage, AgentErrorMessage]]):
-    # A JSON-RPC response object.
     root: Annotated[
         Union[AgentResponseMessage, AgentErrorMessage],
         Field(description="A JSON-RPC response object."),

--- a/tests/test_gen_all.py
+++ b/tests/test_gen_all.py
@@ -1,3 +1,4 @@
+from acp.schema import AvailableCommandInput, ReadTextFileRequest
 from scripts.gen_all import resolve_ref, schema_source_paths
 from scripts.gen_schema import (
     _deserialize_field_specs,
@@ -7,6 +8,16 @@ from scripts.gen_schema import (
     _preprocess_schema_for_codegen,
     _restore_required_nullable_fields,
 )
+
+
+def test_generated_field_descriptions_are_introspectable() -> None:
+    path_description = "Absolute path to the file to read."
+    assert ReadTextFileRequest.model_fields["path"].description == path_description
+    assert ReadTextFileRequest.model_json_schema()["properties"]["path"]["description"] == path_description
+
+    root_description = "The input specification for a command."
+    assert AvailableCommandInput.model_fields["root"].description == root_description
+    assert AvailableCommandInput.model_json_schema()["description"] == root_description
 
 
 def test_resolve_ref_accepts_schema_release_tags() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ provides-extras = ["logfire", "http"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "datamodel-code-generator", specifier = ">=0.25" },
+    { name = "datamodel-code-generator", specifier = ">=0.71.0" },
     { name = "deptry", specifier = ">=0.23.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27" },
     { name = "mkdocs", specifier = ">=1.4.2" },
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.64.0"
+version = "0.71.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -332,9 +332,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/d2/86c94a2836ed42231653a7ddaefa0a5bc23418167a876bba7376c96b3a35/datamodel_code_generator-0.64.0.tar.gz", hash = "sha256:9c592900a00b20e416494273c22435f5a9aef6ea8c7b9190747522a60497a1cb", size = 1316440, upload-time = "2026-06-14T17:24:50.528Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/f5/f4ce23d99503b147c9ec514dc995a96d3b4d2a3284252ad665f875a3145d/datamodel_code_generator-0.71.0.tar.gz", hash = "sha256:d27cd7a0d10f9b2db74a41db7f3e050c226da9cf0afb4916a7ab56275ebacbf2", size = 1684916, upload-time = "2026-07-24T15:32:04.334Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/94/71338e2f0146ac10747a5537b3a1e45256e66b7c229869eb0ee787111b41/datamodel_code_generator-0.64.0-py3-none-any.whl", hash = "sha256:b7cd8bd41a312aa997aec6150670bad781847c5b674f17e4d70e78208a0fb990", size = 374698, upload-time = "2026-06-14T17:24:48.809Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4d/556cb290170f41b97ce50fd872e10a266f141d7a38352bb3071e4ae61f41/datamodel_code_generator-0.71.0-py3-none-any.whl", hash = "sha256:680b68338d59e98a0559eeb54d8e5ca33c35b3ec0bef922ec2cc783f2cb28e9a", size = 452379, upload-time = "2026-07-24T15:32:02.467Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update `datamodel-code-generator` to 0.71.
- Preserve the generated public API across enum and root-model changes.
- Keep field descriptions once as attribute docstrings and regenerate the schema.

Newer generator releases changed their enum and root-model output, so codegen now normalizes those differences without duplicating documentation.

## Related issues

Relates to #47.

## Testing

- `make gen-all` (repeatable output)
- `make check`
- `make test` — 194 passed, 1 skipped on Python 3.14
- Python 3.10 — 193 passed, 2 skipped
- `make docs-test`

## Docs & screenshots

No documentation or screenshot changes are needed; this regenerates schema bindings only.

## Checklist

- [x] Conventional Commit title (e.g. `feat:`, `fix:`).
- [x] Tests cover the change or are not required (explain above).
- [x] Docs/examples updated when behaviour is user-facing.
- [x] Schema regenerations (`make gen-all`) are called out if applicable.
