### PR TITLE
feat(schema): update to 1.21.0

### DIFF
--- a/schema/VERSION
+++ b/schema/VERSION
@@ -1,1 +1,1 @@
-refs/tags/schema-v1.19.0
+refs/tags/schema-v1.21.0

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -228,7 +228,7 @@
                 },
                 {
                   "title": "CreateElicitationRequest",
-                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequests structured user input via a form or URL.",
+                  "description": "Requests structured user input via a form or URL.\n\nSee protocol docs: [Elicitation](https://agentclientprotocol.com/protocol/elicitation)",
                   "allOf": [
                     {
                       "$ref": "#/$defs/CreateElicitationRequest"
@@ -484,6 +484,14 @@
         },
         "title": {
           "description": "Update the human-readable title.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "name": {
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nUpdate the programmatic name of the tool being invoked.\n\nThis field is optional. Omitting it or sending `null` both mean that\nthe existing name is left unchanged.",
           "type": [
             "string",
             "null"
@@ -1599,7 +1607,7 @@
       "x-method": "terminal/kill"
     },
     "CreateElicitationRequest": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest from the agent to elicit structured user input.\n\nThe agent sends this to the client to request information from the user,\neither via a form or by directing them to a URL.\nElicitations are tied to a session (optionally a tool call) or a request.",
+      "description": "Request from the agent to elicit structured user input.\n\nThe agent sends this to the client to request information from the user,\neither via a form or by directing them to a URL.\nElicitations are tied to a session (optionally a tool call) or a request.",
       "type": "object",
       "properties": {
         "message": {
@@ -1607,7 +1615,7 @@
           "type": "string"
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -1717,9 +1725,6 @@
           }
         }
       ],
-      "discriminator": {
-        "propertyName": "mode"
-      },
       "required": [
         "message"
       ],
@@ -1727,7 +1732,7 @@
       "x-method": "elicitation/create"
     },
     "ElicitationSessionScope": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSession-scoped elicitation, optionally tied to a specific tool call.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
+      "description": "Session-scoped elicitation, optionally tied to a specific tool call.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
       "type": "object",
       "properties": {
         "sessionId": {
@@ -1739,7 +1744,7 @@
           ]
         },
         "toolCallId": {
-          "description": "Optional tool call within the session.",
+          "description": "Optional tool call within the session.\n\nOptional. Omitted and `null` are equivalent and mean the elicitation is scoped to the\nsession without a specific tool call.",
           "anyOf": [
             {
               "$ref": "#/$defs/ToolCallId"
@@ -1756,7 +1761,7 @@
       ]
     },
     "ElicitationRequestScope": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest-scoped elicitation, tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
+      "description": "Request-scoped elicitation, tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
       "type": "object",
       "properties": {
         "requestId": {
@@ -1787,7 +1792,7 @@
           ]
         },
         "title": {
-          "description": "Optional title for the schema.",
+          "description": "Optional title for the schema.\n\nOptional. Omitted and `null` are equivalent and mean no title is provided.",
           "type": [
             "string",
             "null"
@@ -1803,7 +1808,7 @@
           }
         },
         "required": {
-          "description": "List of required property names.",
+          "description": "List of required property names.\n\nOptional. Omitted and `null` are equivalent and mean no property names are required.",
           "type": [
             "array",
             "null"
@@ -1813,7 +1818,7 @@
           }
         },
         "description": {
-          "description": "Optional description of what this schema represents.",
+          "description": "Optional description of what this schema represents.\n\nOptional. Omitted and `null` are equivalent and mean no schema description is provided.",
           "type": [
             "string",
             "null"
@@ -1821,7 +1826,7 @@
           "x-deserialize-default-on-error": true
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2013,10 +2018,7 @@
           },
           "additionalProperties": true
         }
-      ],
-      "discriminator": {
-        "propertyName": "type"
-      }
+      ]
     },
     "StringFormat": {
       "description": "String format types for string properties in elicitation schemas.",
@@ -2056,7 +2058,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Human-readable description.",
+          "description": "Human-readable description.\n\nOptional. Omitted and `null` are equivalent and mean no description is provided.",
           "type": [
             "string",
             "null"
@@ -2064,7 +2066,7 @@
           "x-deserialize-default-on-error": true
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2083,7 +2085,7 @@
       "type": "object",
       "properties": {
         "title": {
-          "description": "Optional title for the property.",
+          "description": "Optional title for the property.\n\nOptional. Omitted and `null` are equivalent and mean no title is provided.",
           "type": [
             "string",
             "null"
@@ -2091,7 +2093,7 @@
           "x-deserialize-default-on-error": true
         },
         "description": {
-          "description": "Human-readable description.",
+          "description": "Human-readable description.\n\nOptional. Omitted and `null` are equivalent and mean no description is provided.",
           "type": [
             "string",
             "null"
@@ -2099,7 +2101,7 @@
           "x-deserialize-default-on-error": true
         },
         "minLength": {
-          "description": "Minimum string length.",
+          "description": "Minimum string length.\n\nOptional. Omitted and `null` are equivalent and mean there is no minimum length constraint.",
           "type": [
             "integer",
             "null"
@@ -2108,7 +2110,7 @@
           "minimum": 0
         },
         "maxLength": {
-          "description": "Maximum string length.",
+          "description": "Maximum string length.\n\nOptional. Omitted and `null` are equivalent and mean there is no maximum length constraint.",
           "type": [
             "integer",
             "null"
@@ -2117,14 +2119,14 @@
           "minimum": 0
         },
         "pattern": {
-          "description": "Pattern the string must match.",
+          "description": "Pattern the string must match.\n\nOptional. Omitted and `null` are equivalent and mean there is no pattern constraint.",
           "type": [
             "string",
             "null"
           ]
         },
         "format": {
-          "description": "String format.",
+          "description": "String format.\n\nOptional. Omitted and `null` are equivalent and mean there is no format constraint.",
           "anyOf": [
             {
               "$ref": "#/$defs/StringFormat"
@@ -2135,7 +2137,7 @@
           ]
         },
         "default": {
-          "description": "Default value.",
+          "description": "Default value.\n\nOptional. Omitted and `null` are equivalent and mean no default value is provided.",
           "type": [
             "string",
             "null"
@@ -2143,7 +2145,7 @@
           "x-deserialize-default-on-error": true
         },
         "enum": {
-          "description": "Enum values for untitled single-select enums.",
+          "description": "Enum values for untitled single-select enums.\nOptional. Omitted and `null` are equivalent and mean no untitled single-select choices are\ndeclared by `enum`.",
           "type": [
             "array",
             "null"
@@ -2153,7 +2155,7 @@
           }
         },
         "oneOf": {
-          "description": "Titled enum options for titled single-select enums.",
+          "description": "Titled enum options for titled single-select enums.\nOptional. Omitted and `null` are equivalent and mean no titled single-select choices are\ndeclared by `oneOf`.",
           "type": [
             "array",
             "null"
@@ -2163,7 +2165,7 @@
           }
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2178,7 +2180,7 @@
       "type": "object",
       "properties": {
         "title": {
-          "description": "Optional title for the property.",
+          "description": "Optional title for the property.\n\nOptional. Omitted and `null` are equivalent and mean no title is provided.",
           "type": [
             "string",
             "null"
@@ -2186,7 +2188,7 @@
           "x-deserialize-default-on-error": true
         },
         "description": {
-          "description": "Human-readable description.",
+          "description": "Human-readable description.\n\nOptional. Omitted and `null` are equivalent and mean no description is provided.",
           "type": [
             "string",
             "null"
@@ -2194,7 +2196,7 @@
           "x-deserialize-default-on-error": true
         },
         "minimum": {
-          "description": "Minimum value (inclusive).",
+          "description": "Minimum value (inclusive).\n\nOptional. Omitted and `null` are equivalent and mean there is no inclusive lower bound.",
           "type": [
             "number",
             "null"
@@ -2202,7 +2204,7 @@
           "format": "double"
         },
         "maximum": {
-          "description": "Maximum value (inclusive).",
+          "description": "Maximum value (inclusive).\n\nOptional. Omitted and `null` are equivalent and mean there is no inclusive upper bound.",
           "type": [
             "number",
             "null"
@@ -2210,7 +2212,7 @@
           "format": "double"
         },
         "default": {
-          "description": "Default value.",
+          "description": "Default value.\n\nOptional. Omitted and `null` are equivalent and mean no default value is provided.",
           "type": [
             "number",
             "null"
@@ -2219,7 +2221,7 @@
           "x-deserialize-default-on-error": true
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2234,7 +2236,7 @@
       "type": "object",
       "properties": {
         "title": {
-          "description": "Optional title for the property.",
+          "description": "Optional title for the property.\n\nOptional. Omitted and `null` are equivalent and mean no title is provided.",
           "type": [
             "string",
             "null"
@@ -2242,7 +2244,7 @@
           "x-deserialize-default-on-error": true
         },
         "description": {
-          "description": "Human-readable description.",
+          "description": "Human-readable description.\n\nOptional. Omitted and `null` are equivalent and mean no description is provided.",
           "type": [
             "string",
             "null"
@@ -2250,7 +2252,7 @@
           "x-deserialize-default-on-error": true
         },
         "minimum": {
-          "description": "Minimum value (inclusive).",
+          "description": "Minimum value (inclusive).\n\nOptional. Omitted and `null` are equivalent and mean there is no inclusive lower bound.",
           "type": [
             "integer",
             "null"
@@ -2258,7 +2260,7 @@
           "format": "int64"
         },
         "maximum": {
-          "description": "Maximum value (inclusive).",
+          "description": "Maximum value (inclusive).\n\nOptional. Omitted and `null` are equivalent and mean there is no inclusive upper bound.",
           "type": [
             "integer",
             "null"
@@ -2266,7 +2268,7 @@
           "format": "int64"
         },
         "default": {
-          "description": "Default value.",
+          "description": "Default value.\n\nOptional. Omitted and `null` are equivalent and mean no default value is provided.",
           "type": [
             "integer",
             "null"
@@ -2275,7 +2277,7 @@
           "x-deserialize-default-on-error": true
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2290,7 +2292,7 @@
       "type": "object",
       "properties": {
         "title": {
-          "description": "Optional title for the property.",
+          "description": "Optional title for the property.\n\nOptional. Omitted and `null` are equivalent and mean no title is provided.",
           "type": [
             "string",
             "null"
@@ -2298,7 +2300,7 @@
           "x-deserialize-default-on-error": true
         },
         "description": {
-          "description": "Human-readable description.",
+          "description": "Human-readable description.\n\nOptional. Omitted and `null` are equivalent and mean no description is provided.",
           "type": [
             "string",
             "null"
@@ -2306,7 +2308,7 @@
           "x-deserialize-default-on-error": true
         },
         "default": {
-          "description": "Default value.",
+          "description": "Default value.\n\nOptional. Omitted and `null` are equivalent and mean no default value is provided.",
           "type": [
             "boolean",
             "null"
@@ -2314,7 +2316,7 @@
           "x-deserialize-default-on-error": true
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2385,10 +2387,7 @@
             }
           ]
         }
-      ],
-      "discriminator": {
-        "propertyName": "type"
-      }
+      ]
     },
     "StringMultiSelectItems": {
       "description": "String item schema for multi-select enum properties.",
@@ -2402,7 +2401,7 @@
           }
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2427,7 +2426,7 @@
           }
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2445,7 +2444,7 @@
       "type": "object",
       "properties": {
         "title": {
-          "description": "Optional title for the property.",
+          "description": "Optional title for the property.\n\nOptional. Omitted and `null` are equivalent and mean no title is provided.",
           "type": [
             "string",
             "null"
@@ -2453,7 +2452,7 @@
           "x-deserialize-default-on-error": true
         },
         "description": {
-          "description": "Human-readable description.",
+          "description": "Human-readable description.\n\nOptional. Omitted and `null` are equivalent and mean no description is provided.",
           "type": [
             "string",
             "null"
@@ -2461,7 +2460,7 @@
           "x-deserialize-default-on-error": true
         },
         "minItems": {
-          "description": "Minimum number of items to select.",
+          "description": "Minimum number of items to select.\n\nOptional. Omitted and `null` are equivalent and mean there is no minimum selection count.",
           "type": [
             "integer",
             "null"
@@ -2470,7 +2469,7 @@
           "minimum": 0
         },
         "maxItems": {
-          "description": "Maximum number of items to select.",
+          "description": "Maximum number of items to select.\n\nOptional. Omitted and `null` are equivalent and mean there is no maximum selection count.",
           "type": [
             "integer",
             "null"
@@ -2487,7 +2486,7 @@
           ]
         },
         "default": {
-          "description": "Default selected values.",
+          "description": "Default selected values.\n\nOptional. Omitted and `null` are equivalent and mean no default selections are provided.",
           "type": [
             "array",
             "null"
@@ -2499,7 +2498,7 @@
           "x-deserialize-skip-invalid-items": true
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -2513,7 +2512,7 @@
       ]
     },
     "ElicitationFormMode": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation mode where the client renders a form from the provided schema.",
+      "description": "Form-based elicitation mode where the client renders a form from the provided schema.",
       "type": "object",
       "properties": {
         "requestedSchema": {
@@ -2550,11 +2549,11 @@
       ]
     },
     "ElicitationId": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nUnique identifier for an elicitation.",
+      "description": "Unique identifier for an elicitation.",
       "type": "string"
     },
     "ElicitationUrlMode": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation mode where the client directs the user to a URL.",
+      "description": "URL-based elicitation mode where the client directs the user to a URL.",
       "type": "object",
       "properties": {
         "elicitationId": {
@@ -3909,25 +3908,7 @@
       "description": "Describes an available authentication method.\n\nThe `type` field acts as the discriminator in the serialized JSON form.\nWhen no `type` is present, the method is treated as `agent`.",
       "anyOf": [
         {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nUser provides a key that the client passes to the agent as an environment variable.",
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "env_var"
-            }
-          },
-          "required": [
-            "type"
-          ],
-          "allOf": [
-            {
-              "$ref": "#/$defs/AuthMethodEnvVar"
-            }
-          ]
-        },
-        {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nClient runs an interactive terminal for the user to authenticate via a TUI.",
+          "description": "Client runs the configured agent program as a separate interactive\nprocess, without passing this method to `authenticate`.",
           "type": "object",
           "properties": {
             "type": {
@@ -3946,7 +3927,7 @@
         },
         {
           "title": "agent",
-          "description": "Agent handles authentication itself.\n\nThis is the default when no `type` is specified.",
+          "description": "Agent handles authentication itself through `authenticate`.\n\nThis is the default when no `type` is specified.",
           "allOf": [
             {
               "$ref": "#/$defs/AuthMethodAgent"
@@ -3959,107 +3940,8 @@
       "description": "Typed identifier used for auth method values on the wire.",
       "type": "string"
     },
-    "AuthEnvVar": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nDescribes a single environment variable for an [`AuthMethodEnvVar`] authentication method.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "The environment variable name (e.g. `\"OPENAI_API_KEY\"`).",
-          "type": "string"
-        },
-        "label": {
-          "description": "Human-readable label for this variable, displayed in client UI.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "x-deserialize-default-on-error": true
-        },
-        "secret": {
-          "description": "Whether this value is a secret (e.g. API key, token).\nClients should use a password-style input for secret vars.\n\nDefaults to `true`.",
-          "type": "boolean",
-          "x-deserialize-default-on-error": true,
-          "default": true
-        },
-        "optional": {
-          "description": "Whether this variable is optional.\n\nDefaults to `false`.",
-          "type": "boolean",
-          "x-deserialize-default-on-error": true,
-          "default": false
-        },
-        "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": [
-            "object",
-            "null"
-          ],
-          "x-deserialize-default-on-error": true,
-          "additionalProperties": true
-        }
-      },
-      "required": [
-        "name"
-      ]
-    },
-    "AuthMethodEnvVar": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nEnvironment variable authentication method.\n\nThe user provides credentials that the client passes to the agent as environment variables.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this authentication method.",
-          "allOf": [
-            {
-              "$ref": "#/$defs/AuthMethodId"
-            }
-          ]
-        },
-        "name": {
-          "description": "Human-readable name of the authentication method.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Optional description providing more details about this authentication method.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "x-deserialize-default-on-error": true
-        },
-        "vars": {
-          "description": "The environment variables the client should set.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/AuthEnvVar"
-          },
-          "x-deserialize-default-on-error": true,
-          "x-deserialize-skip-invalid-items": true
-        },
-        "link": {
-          "description": "Optional link to a page where the user can obtain their credentials.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "x-deserialize-default-on-error": true
-        },
-        "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": [
-            "object",
-            "null"
-          ],
-          "x-deserialize-default-on-error": true,
-          "additionalProperties": true
-        }
-      },
-      "required": [
-        "id",
-        "name",
-        "vars"
-      ]
-    },
     "AuthMethodTerminal": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nTerminal-based authentication method.\n\nThe client runs an interactive terminal for the user to authenticate via a TUI.",
+      "description": "Terminal-based authentication method.\n\nThe client runs the configured agent program as a separate interactive\nprocess for the user to authenticate via a TUI. Agents MUST advertise this\nmethod only when the client enabled its terminal authentication capability.\nA zero exit status signals success; any other termination signals failure.\nThe client MUST NOT pass this method to `authenticate`.",
       "type": "object",
       "properties": {
         "id": {
@@ -4083,7 +3965,7 @@
           "x-deserialize-default-on-error": true
         },
         "args": {
-          "description": "Additional arguments to pass when running the agent binary for terminal auth.",
+          "description": "Additional arguments to append to the configured agent invocation for terminal auth.",
           "type": "array",
           "items": {
             "type": "string"
@@ -4092,7 +3974,7 @@
           "x-deserialize-skip-invalid-items": true
         },
         "env": {
-          "description": "Additional environment variables to set when running the agent binary for terminal auth.",
+          "description": "Additional environment variables to set on the configured agent invocation for terminal auth.\nThese values override same-named variables in the base launch configuration.",
           "type": "object",
           "x-deserialize-default-on-error": true,
           "additionalProperties": {
@@ -4115,7 +3997,7 @@
       ]
     },
     "AuthMethodAgent": {
-      "description": "Agent handles authentication itself.\n\nThis is the default authentication method type.",
+      "description": "Agent handles authentication itself through `authenticate`.\n\nThis is the default authentication method type.",
       "type": "object",
       "properties": {
         "id": {
@@ -5818,7 +5700,7 @@
                 },
                 {
                   "title": "CompleteElicitationNotification",
-                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNotification that a URL-based elicitation has completed.",
+                  "description": "Notification that a URL-based elicitation has completed.\n\nSee protocol docs: [Elicitation](https://agentclientprotocol.com/protocol/elicitation#url-completion)",
                   "allOf": [
                     {
                       "$ref": "#/$defs/CompleteElicitationNotification"
@@ -6129,6 +6011,42 @@
               "$ref": "#/$defs/UsageUpdate"
             }
           ]
+        },
+        {
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA context compaction has been created or updated.\n\nAgents MUST only send this update when the Client advertised\n[`ClientSessionCapabilities::compaction`].",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "compaction_update"
+            }
+          },
+          "required": [
+            "sessionUpdate"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/$defs/CompactionUpdate"
+            }
+          ]
+        },
+        {
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA content block appended to a context compaction's retained summary.\n\nAgents MUST only send this update when the Client advertised\n[`ClientSessionCapabilities::compaction`].",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "compaction_summary_chunk"
+            }
+          },
+          "required": [
+            "sessionUpdate"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/$defs/CompactionSummaryChunk"
+            }
+          ]
         }
       ],
       "discriminator": {
@@ -6192,6 +6110,14 @@
         "title": {
           "description": "Human-readable title describing what the tool is doing.",
           "type": "string"
+        },
+        "name": {
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProgrammatic name of the tool being invoked.\n\nThis field is optional. Omitting it or sending `null` both mean that no\ntool name is available.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "x-deserialize-default-on-error": true
         },
         "kind": {
           "description": "The category of tool being invoked.\nHelps clients choose appropriate icons and UI treatment.",
@@ -6832,8 +6758,132 @@
         "size"
       ]
     },
+    "CompactionId": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nUnique identifier for a context compaction within a session.",
+      "type": "string"
+    },
+    "CompactionStatus": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nLifecycle state of a context compaction.",
+      "anyOf": [
+        {
+          "description": "Compaction has started and has not finished.",
+          "type": "string",
+          "const": "in_progress"
+        },
+        {
+          "description": "Compaction finished successfully.",
+          "type": "string",
+          "const": "completed"
+        },
+        {
+          "description": "Compaction finished unsuccessfully.",
+          "type": "string",
+          "const": "failed"
+        },
+        {
+          "description": "Compaction was cancelled before it finished.",
+          "type": "string",
+          "const": "cancelled"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future compaction status.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Other unknown values are reserved for future ACP statuses.",
+          "type": "string"
+        }
+      ]
+    },
+    "CompactionUpdate": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA context compaction upsert. The first update fixes the compaction's\ntimeline position. Later updates with the same ID patch that entity in place.\nAgents MUST only send this update when the Client advertised\n[`ClientSessionCapabilities::compaction`].\n\n`summary`, `error`, and `_meta` have patch semantics: omission leaves the\nstored value unchanged, `null` clears it, and a concrete value replaces it.\n`summary: []` also clears the retained summary. A non-empty summary is only\nvalid with `completed`; `error` is only valid with `failed`.",
+      "type": "object",
+      "properties": {
+        "compactionId": {
+          "description": "The Agent-owned ID of this compaction, unique within the session.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/CompactionId"
+            }
+          ]
+        },
+        "status": {
+          "description": "Current lifecycle status.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/CompactionStatus"
+            }
+          ]
+        },
+        "summary": {
+          "description": "Complete replacement user-displayable summary retained by the compaction.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "error": {
+          "description": "Human-readable description of why the compaction failed.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "Extensible metadata patch for this compaction.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "compactionId",
+        "status"
+      ]
+    },
+    "CompactionSummaryChunk": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA content block appended to the retained summary of an in-progress\ncompaction. Agents send chunks only after an `in_progress` update and before\nthe terminal update for the same ID. Agents MUST only send this update when\nthe Client advertised [`ClientSessionCapabilities::compaction`].",
+      "type": "object",
+      "properties": {
+        "compactionId": {
+          "description": "ID of the compaction whose summary receives this content.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/CompactionId"
+            }
+          ]
+        },
+        "content": {
+          "description": "One content block to append.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ContentBlock"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "Metadata scoped to this chunk. Omission and `null` both mean absent.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "compactionId",
+        "content"
+      ]
+    },
     "CompleteElicitationNotification": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNotification sent by the agent when a URL-based elicitation is complete.",
+      "description": "Notification sent by the agent when a URL-based elicitation is complete.",
       "type": "object",
       "properties": {
         "elicitationId": {
@@ -6845,7 +6895,7 @@
           ]
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -6938,7 +6988,7 @@
                 },
                 {
                   "title": "AuthenticateRequest",
-                  "description": "Authenticates the client using the specified authentication method.\n\nCalled when the agent requires authentication before allowing session creation.\nThe client provides the authentication method ID that was advertised during initialization.\n\nAfter successful authentication, the client can proceed to create sessions with\n`new_session` without receiving an `auth_required` error.\n\nSee protocol docs: [Initialization](https://agentclientprotocol.com/protocol/initialization)",
+                  "description": "Authenticates the client using the specified authentication method.\n\nCalled when the agent requires authentication before allowing session creation.\nThe client provides an authentication method ID that was advertised during\ninitialization and whose type defines the `authenticate` flow.\n\nAfter successful authentication, the client can proceed to create sessions with\n`new_session` without receiving an `auth_required` error.\n\nSee protocol docs: [Initialization](https://agentclientprotocol.com/protocol/initialization)",
                   "allOf": [
                     {
                       "$ref": "#/$defs/AuthenticateRequest"
@@ -7237,7 +7287,7 @@
           "x-deserialize-default-on-error": true
         },
         "auth": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`.",
+          "description": "Authentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`.",
           "x-deserialize-default-on-error": true,
           "default": {
             "terminal": false
@@ -7249,7 +7299,7 @@
           ]
         },
         "elicitation": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.\n\nOptional. Omitted or `null` both mean the client does not advertise\nelicitation support.",
+          "description": "Elicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.\n\nOptional. Omitted or `null` both mean the client does not advertise\nelicitation support.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationCapabilities"
@@ -7323,6 +7373,18 @@
       "description": "Session-related capabilities supported by the client.",
       "type": "object",
       "properties": {
+        "compaction": {
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSupport for ID-addressed context compaction updates. Omitted or `null`\nmeans unsupported; `{}` advertises the complete compaction contract.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompactionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
         "configOptions": {
           "description": "Config option capabilities supported by the client.\n\nOmitted or `null` both mean the client does not advertise support for any\nconfig option extensions.",
           "anyOf": [
@@ -7345,6 +7407,10 @@
           "additionalProperties": true
         }
       }
+    },
+    "CompactionCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nClient support for ID-addressed context compaction updates.",
+      "type": "object"
     },
     "SessionConfigOptionsCapabilities": {
       "description": "Session configuration option capabilities supported by the client.",
@@ -7404,11 +7470,11 @@
       }
     },
     "AuthCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\n\nAdvertised during initialization to inform the agent which authentication\nmethod types the client can handle. This governs opt-in types that require\nadditional client-side support.",
+      "description": "Authentication capabilities supported by the client.\n\nAdvertised during initialization to inform the agent which authentication\nmethod types the client can handle. This governs opt-in types that require\nadditional client-side support.",
       "type": "object",
       "properties": {
         "terminal": {
-          "description": "Whether the client supports `terminal` authentication methods.\n\nWhen `true`, the agent may include `terminal` entries in its authentication methods.",
+          "description": "Whether the client supports `terminal` authentication methods.\n\nThe client should set this to `true` only when it can reproduce the\nconfigured agent invocation in an interactive terminal. When `true`, the\nagent may include `terminal` entries in its authentication methods.",
           "type": "boolean",
           "default": false,
           "x-deserialize-default-on-error": true
@@ -7425,11 +7491,11 @@
       }
     },
     "ElicitationCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.",
+      "description": "Elicitation capabilities supported by the client.",
       "type": "object",
       "properties": {
         "form": {
-          "description": "Whether the client supports form-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports form-based elicitation.",
+          "description": "Whether the client supports form-based elicitation.\n\nOptional. Omitted and `null` are equivalent and mean form support is not advertised.\nSupplying `{}` explicitly advertises form support.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationFormCapabilities"
@@ -7453,7 +7519,7 @@
           "x-deserialize-default-on-error": true
         },
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -7464,11 +7530,11 @@
       }
     },
     "ElicitationFormCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation capabilities.\n\nSupplying `{}` means the client supports form-based elicitation.",
+      "description": "Form-based elicitation capabilities.\n\nSupplying `{}` means the client supports form-based elicitation.",
       "type": "object",
       "properties": {
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -7479,11 +7545,11 @@
       }
     },
     "ElicitationUrlCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation capabilities.\n\nSupplying `{}` means the client supports URL-based elicitation.",
+      "description": "URL-based elicitation capabilities.\n\nSupplying `{}` means the client supports URL-based elicitation.",
       "type": "object",
       "properties": {
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -9474,11 +9540,11 @@
       "x-method": "terminal/kill"
     },
     "CreateElicitationResponse": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse from the client to an elicitation request.",
+      "description": "Response from the client to an elicitation request.",
       "type": "object",
       "properties": {
         "_meta": {
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nOptional. Omitted and `null` are equivalent and mean no metadata.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": [
             "object",
             "null"
@@ -9588,9 +9654,6 @@
           "additionalProperties": true
         }
       ],
-      "discriminator": {
-        "propertyName": "action"
-      },
       "x-side": "client",
       "x-method": "elicitation/create"
     },
@@ -9630,7 +9693,7 @@
       ]
     },
     "ElicitationAcceptAction": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe user accepted the elicitation and provided content.",
+      "description": "The user accepted the elicitation and provided content.",
       "type": "object",
       "properties": {
         "content": {

--- a/scripts/gen_schema.py
+++ b/scripts/gen_schema.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import copy
 import difflib
 import json
 import subprocess
@@ -33,13 +32,6 @@ UNSIGNED_TYPE_MAPPINGS = (
     "integer+uint32=integer",
     "integer+uint64=integer",
 )
-
-OPEN_UNIONS = {
-    "CreateElicitationRequest": 2,
-    "CreateElicitationResponse": 3,
-    "ElicitationPropertySchema": 5,
-    "MultiSelectItems": 1,
-}
 
 
 def _inline_model_ref(definition: str, *steps: tuple[str, int | None]) -> str:
@@ -312,7 +304,7 @@ def render_schema() -> str:
     if not SCHEMA_JSON.exists():
         raise FileNotFoundError("schema/schema.json is missing; fetch a pinned schema release first")
 
-    schema = _schema_for_codegen(json.loads(SCHEMA_JSON.read_text(encoding="utf-8")))
+    schema = json.loads(SCHEMA_JSON.read_text(encoding="utf-8"))
     generated = generate(
         schema,
         input_file_type=InputFileType.JsonSchema,
@@ -346,18 +338,6 @@ def render_schema() -> str:
     if not isinstance(generated, str):
         raise TypeError("Schema generation did not produce a single Python module")
     return _format_python(f"{generated.rstrip()}\n\n\n{COMPATIBILITY_ALIASES}\n")
-
-
-def _schema_for_codegen(schema: dict[str, Any]) -> dict[str, Any]:
-    """Drop open-union constraints that Pydantic cannot represent statically."""
-    patched = copy.deepcopy(schema)
-    for name, catchall_index in OPEN_UNIONS.items():
-        try:
-            del patched["$defs"][name]["discriminator"]
-            del patched["$defs"][name]["anyOf"][catchall_index]["not"]
-        except KeyError:
-            raise ValueError(f"{name} no longer has the expected open-union shape") from None
-    return patched
 
 
 def _build_validators_config(schema: dict[str, Any]) -> dict[str, ModelValidators]:

--- a/scripts/gen_signature.py
+++ b/scripts/gen_signature.py
@@ -2,6 +2,7 @@ import ast
 import importlib.util
 import inspect
 import sys
+import types
 import typing as t
 from pathlib import Path
 
@@ -35,7 +36,6 @@ class NodeTransformer(ast.NodeTransformer):
     def __init__(self) -> None:
         self._type_import_node: ast.ImportFrom | None = None
         self._schema_import_node: ast.ImportFrom | None = None
-        self._should_rewrite = False
         self._literals = {name: value for name, value in schema.__dict__.items() if t.get_origin(value) is t.Literal}
         self._current_model_name: str | None = None
 
@@ -44,21 +44,20 @@ class NodeTransformer(ast.NodeTransformer):
             return
         if not any(alias.name == name for alias in self._type_import_node.names):
             self._type_import_node.names.append(ast.alias(name=name))
-            self._should_rewrite = True
 
     def _add_schema_import(self, name: str) -> None:
         if not self._schema_import_node:
             return
         if not any(alias.name == name for alias in self._schema_import_node.names):
             self._schema_import_node.names.append(ast.alias(name=name))
-            self._should_rewrite = True
 
     def transform(self, source_file: Path) -> None:
         with source_file.open("r", encoding="utf-8") as f:
             source_code = f.read()
         tree = ast.parse(source_code)
+        before = ast.dump(tree, include_attributes=False)
         self.visit(tree)
-        if self._should_rewrite:
+        if ast.dump(tree, include_attributes=False) != before:
             print("Rewriting signatures in", source_file)
             new_code = ast.unparse(tree)
             with source_file.open("w", encoding="utf-8") as f:
@@ -90,7 +89,6 @@ class NodeTransformer(ast.NodeTransformer):
         )
         if not decorator:
             return self.generic_visit(node)
-        self._should_rewrite = True
         model_name = t.cast(ast.Name, decorator.args[0]).id
         model = t.cast(type[schema.BaseModel], getattr(schema, model_name))
         self._current_model_name = model_name
@@ -130,6 +128,12 @@ class NodeTransformer(ast.NodeTransformer):
         origin = t.get_origin(annotation)
         if origin is t.Annotated:
             return self._format_annotation(t.get_args(annotation)[0])
+        if origin in (t.Union, types.UnionType):
+            first, *rest = t.get_args(annotation)
+            formatted = self._format_annotation(first)
+            for argument in rest:
+                formatted = ast.BinOp(left=formatted, op=ast.BitOr(), right=self._format_annotation(argument))
+            return formatted
         if origin is t.Literal and annotation in self._literals.values():
             name = next(name for name, value in self._literals.items() if value is annotation)
             self._add_schema_import(name)

--- a/src/acp/agent/connection.py
+++ b/src/acp/agent/connection.py
@@ -49,6 +49,8 @@ from ..schema import (
     RequestPermissionResponse,
     SessionInfoUpdate,
     SessionNotification,
+    SessionUpdateCompactionSummaryChunk,
+    SessionUpdateCompactionUpdate,
     TerminalOutputRequest,
     TerminalOutputResponse,
     ToolCallProgress,
@@ -121,7 +123,9 @@ class AgentSideConnection:
         | CurrentModeUpdate
         | ConfigOptionUpdate
         | SessionInfoUpdate
-        | UsageUpdate,
+        | UsageUpdate
+        | SessionUpdateCompactionUpdate
+        | SessionUpdateCompactionSummaryChunk,
         **kwargs: Any,
     ) -> None:
         await notify_model(

--- a/src/acp/contrib/tool_calls.py
+++ b/src/acp/contrib/tool_calls.py
@@ -56,6 +56,7 @@ class TrackedToolCallView(BaseModel):
 
     tool_call_id: str
     title: str | None
+    name: str | None
     kind: ToolKind | None
     status: ToolCallStatus | None
     content: tuple[Any, ...] | None
@@ -70,6 +71,7 @@ class _TrackedToolCall:
         *,
         tool_call_id: str,
         title: str | None = None,
+        name: str | None = None,
         kind: ToolKind | None = None,
         status: ToolCallStatus | None = None,
         content: Sequence[Any] | None = None,
@@ -79,6 +81,7 @@ class _TrackedToolCall:
     ) -> None:
         self.tool_call_id = tool_call_id
         self.title = title
+        self.name = name
         self.kind = kind
         self.status = status
         self.content = _copy_model_list(content)
@@ -91,6 +94,7 @@ class _TrackedToolCall:
         return TrackedToolCallView(
             tool_call_id=self.tool_call_id,
             title=self.title,
+            name=self.name,
             kind=self.kind,
             status=self.status,
             content=tuple(item.model_copy(deep=True) for item in self.content) if self.content else None,
@@ -103,6 +107,7 @@ class _TrackedToolCall:
         return ToolCallUpdate(
             tool_call_id=self.tool_call_id,
             title=self.title,
+            name=self.name,
             kind=self.kind,
             status=self.status,
             content=_copy_model_list(self.content),
@@ -118,6 +123,7 @@ class _TrackedToolCall:
             session_update="tool_call",
             tool_call_id=self.tool_call_id,
             title=self.title,
+            name=self.name,
             kind=self.kind,
             status=self.status,
             content=_copy_model_list(self.content),
@@ -130,6 +136,7 @@ class _TrackedToolCall:
         self,
         *,
         title: Any = UNSET,
+        name: Any = UNSET,
         kind: Any = UNSET,
         status: Any = UNSET,
         content: Any = UNSET,
@@ -141,6 +148,9 @@ class _TrackedToolCall:
         if title is not UNSET:
             self.title = cast(str | None, title)
             kwargs["title"] = self.title
+        if name is not UNSET:
+            self.name = cast(str | None, name)
+            kwargs["name"] = self.name
         if kind is not UNSET:
             self.kind = cast(ToolKind | None, kind)
             kwargs["kind"] = self.kind
@@ -190,6 +200,7 @@ class ToolCallTracker:
         external_id: str,
         *,
         title: str,
+        name: str | None = None,
         kind: ToolKind | None = None,
         status: ToolCallStatus | None = "in_progress",
         content: Sequence[Any] | None = None,
@@ -202,6 +213,7 @@ class ToolCallTracker:
         state = _TrackedToolCall(
             tool_call_id=call_id,
             title=title,
+            name=name,
             kind=kind,
             status=status,
             content=content,
@@ -217,6 +229,7 @@ class ToolCallTracker:
         external_id: str,
         *,
         title: Any = UNSET,
+        name: Any = UNSET,
         kind: Any = UNSET,
         status: Any = UNSET,
         content: Any = UNSET,
@@ -228,6 +241,7 @@ class ToolCallTracker:
         state = self._require_call(external_id)
         return state.update(
             title=title,
+            name=name,
             kind=kind,
             status=status,
             content=content,

--- a/src/acp/interfaces.py
+++ b/src/acp/interfaces.py
@@ -56,6 +56,8 @@ from .schema import (
     ResumeSessionResponse,
     SessionInfoUpdate,
     SessionNotification,
+    SessionUpdateCompactionSummaryChunk,
+    SessionUpdateCompactionUpdate,
     SetSessionConfigOptionBooleanRequest,
     SetSessionConfigOptionResponse,
     SetSessionConfigOptionSelectRequest,
@@ -102,7 +104,9 @@ class Client(Protocol):
         | CurrentModeUpdate
         | ConfigOptionUpdate
         | SessionInfoUpdate
-        | UsageUpdate,
+        | UsageUpdate
+        | SessionUpdateCompactionUpdate
+        | SessionUpdateCompactionSummaryChunk,
         **kwargs: Any,
     ) -> None: ...
 

--- a/src/acp/meta.py
+++ b/src/acp/meta.py
@@ -1,5 +1,5 @@
 # Generated from schema/meta.json. Do not edit by hand.
-# Schema ref: refs/tags/schema-v1.19.0
+# Schema ref: refs/tags/schema-v1.21.0
 AGENT_METHODS = {
     "initialize": "initialize",
     "authenticate": "authenticate",

--- a/src/acp/schema.py
+++ b/src/acp/schema.py
@@ -1,5 +1,5 @@
 # Generated from schema/schema.json. Do not edit by hand.
-# Schema ref: refs/tags/schema-v1.19.0
+# Schema ref: refs/tags/schema-v1.21.0
 
 from __future__ import annotations
 
@@ -272,6 +272,8 @@ class CreateFormElicitationRequestBase(BaseModel):
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
     mode: Literal["form"] = "form"
@@ -288,6 +290,8 @@ class CreateUrlElicitationRequestBase(BaseModel):
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
     mode: Literal["url"] = "url"
@@ -301,6 +305,9 @@ class ElicitationSessionScope(BaseModel):
     tool_call_id: Annotated[Optional[str], Field(alias="toolCallId")] = None
     """
     Optional tool call within the session.
+
+    Optional. Omitted and `null` are equivalent and mean the elicitation is scoped to the
+    session without a specific tool call.
     """
 
     @field_validator("tool_call_id", mode="wrap")
@@ -342,12 +349,16 @@ class EnumOption(BaseModel):
     description: Optional[str] = None
     """
     Human-readable description.
+
+    Optional. Omitted and `null` are equivalent and mean no description is provided.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -362,44 +373,64 @@ class StringPropertySchema(BaseModel):
     title: Optional[str] = None
     """
     Optional title for the property.
+
+    Optional. Omitted and `null` are equivalent and mean no title is provided.
     """
     description: Optional[str] = None
     """
     Human-readable description.
+
+    Optional. Omitted and `null` are equivalent and mean no description is provided.
     """
     min_length: Annotated[Optional[int], Field(alias="minLength", ge=0)] = None
     """
     Minimum string length.
+
+    Optional. Omitted and `null` are equivalent and mean there is no minimum length constraint.
     """
     max_length: Annotated[Optional[int], Field(alias="maxLength", ge=0)] = None
     """
     Maximum string length.
+
+    Optional. Omitted and `null` are equivalent and mean there is no maximum length constraint.
     """
     pattern: Optional[str] = None
     """
     Pattern the string must match.
+
+    Optional. Omitted and `null` are equivalent and mean there is no pattern constraint.
     """
     format: Optional[Literal["email", "uri", "date", "date-time"]] = None
     """
     String format.
+
+    Optional. Omitted and `null` are equivalent and mean there is no format constraint.
     """
     default: Optional[str] = None
     """
     Default value.
+
+    Optional. Omitted and `null` are equivalent and mean no default value is provided.
     """
     enum: Optional[List[str]] = None
     """
     Enum values for untitled single-select enums.
+    Optional. Omitted and `null` are equivalent and mean no untitled single-select choices are
+    declared by `enum`.
     """
     one_of: Annotated[Optional[List[EnumOption]], Field(alias="oneOf")] = None
     """
     Titled enum options for titled single-select enums.
+    Optional. Omitted and `null` are equivalent and mean no titled single-select choices are
+    declared by `oneOf`.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -414,28 +445,40 @@ class NumberPropertySchema(BaseModel):
     title: Optional[str] = None
     """
     Optional title for the property.
+
+    Optional. Omitted and `null` are equivalent and mean no title is provided.
     """
     description: Optional[str] = None
     """
     Human-readable description.
+
+    Optional. Omitted and `null` are equivalent and mean no description is provided.
     """
     minimum: Optional[float] = None
     """
     Minimum value (inclusive).
+
+    Optional. Omitted and `null` are equivalent and mean there is no inclusive lower bound.
     """
     maximum: Optional[float] = None
     """
     Maximum value (inclusive).
+
+    Optional. Omitted and `null` are equivalent and mean there is no inclusive upper bound.
     """
     default: Optional[float] = None
     """
     Default value.
+
+    Optional. Omitted and `null` are equivalent and mean no default value is provided.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -450,28 +493,40 @@ class IntegerPropertySchema(BaseModel):
     title: Optional[str] = None
     """
     Optional title for the property.
+
+    Optional. Omitted and `null` are equivalent and mean no title is provided.
     """
     description: Optional[str] = None
     """
     Human-readable description.
+
+    Optional. Omitted and `null` are equivalent and mean no description is provided.
     """
     minimum: Optional[int] = None
     """
     Minimum value (inclusive).
+
+    Optional. Omitted and `null` are equivalent and mean there is no inclusive lower bound.
     """
     maximum: Optional[int] = None
     """
     Maximum value (inclusive).
+
+    Optional. Omitted and `null` are equivalent and mean there is no inclusive upper bound.
     """
     default: Optional[int] = None
     """
     Default value.
+
+    Optional. Omitted and `null` are equivalent and mean no default value is provided.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -486,20 +541,28 @@ class BooleanPropertySchema(BaseModel):
     title: Optional[str] = None
     """
     Optional title for the property.
+
+    Optional. Omitted and `null` are equivalent and mean no title is provided.
     """
     description: Optional[str] = None
     """
     Human-readable description.
+
+    Optional. Omitted and `null` are equivalent and mean no description is provided.
     """
     default: Optional[bool] = None
     """
     Default value.
+
+    Optional. Omitted and `null` are equivalent and mean no default value is provided.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -535,6 +598,8 @@ class StringMultiSelectItemsBase(BaseModel):
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
 
@@ -549,6 +614,8 @@ class TitledMultiSelectItems(BaseModel):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -579,10 +646,6 @@ class ElicitationUrlRequestMode(ElicitationRequestScope):
 class ElicitationUrlMode(RootModel[Union[ElicitationUrlSessionMode, ElicitationUrlRequestMode]]):
     root: Union[ElicitationUrlSessionMode, ElicitationUrlRequestMode]
     """
-    **UNSTABLE**
-
-    This capability is not part of the spec yet, and may be removed or changed at any point.
-
     URL-based elicitation mode where the client directs the user to a URL.
     """
 
@@ -890,84 +953,6 @@ class NesDiagnosticsCapabilities(BaseModel):
     """
 
 
-class AuthEnvVar(BaseModel):
-    name: str
-    """
-    The environment variable name (e.g. `"OPENAI_API_KEY"`).
-    """
-    label: Optional[str] = None
-    """
-    Human-readable label for this variable, displayed in client UI.
-    """
-    secret: Optional[bool] = True
-    """
-    Whether this value is a secret (e.g. API key, token).
-    Clients should use a password-style input for secret vars.
-
-    Defaults to `true`.
-    """
-    optional: Optional[bool] = False
-    """
-    Whether this variable is optional.
-
-    Defaults to `false`.
-    """
-    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
-    """
-    The _meta property is reserved by ACP to allow clients and agents to attach additional
-    metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    these keys.
-
-    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    """
-
-    @field_validator("label", "optional", "secret", mode="wrap")
-    @classmethod
-    def use_default_on_error_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
-        return use_default_on_error(v, handler, info)
-
-
-class AuthMethodEnvVar(BaseModel):
-    id: str
-    """
-    Unique identifier for this authentication method.
-    """
-    name: str
-    """
-    Human-readable name of the authentication method.
-    """
-    description: Optional[str] = None
-    """
-    Optional description providing more details about this authentication method.
-    """
-    vars: List[AuthEnvVar]
-    """
-    The environment variables the client should set.
-    """
-    link: Optional[str] = None
-    """
-    Optional link to a page where the user can obtain their credentials.
-    """
-    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
-    """
-    The _meta property is reserved by ACP to allow clients and agents to attach additional
-    metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    these keys.
-
-    See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    """
-
-    @field_validator("description", "link", mode="wrap")
-    @classmethod
-    def use_default_on_error_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
-        return use_default_on_error(v, handler, info)
-
-    @field_validator("vars", mode="wrap")
-    @classmethod
-    def skip_invalid_items_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
-        return skip_invalid_items(v, handler, info)
-
-
 class AuthMethodTerminal(BaseModel):
     id: str
     """
@@ -983,11 +968,12 @@ class AuthMethodTerminal(BaseModel):
     """
     args: Optional[List[str]] = None
     """
-    Additional arguments to pass when running the agent binary for terminal auth.
+    Additional arguments to append to the configured agent invocation for terminal auth.
     """
     env: Optional[Dict[str, str]] = None
     """
-    Additional environment variables to set when running the agent binary for terminal auth.
+    Additional environment variables to set on the configured agent invocation for terminal auth.
+    These values override same-named variables in the base launch configuration.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
@@ -1598,6 +1584,8 @@ class CompleteElicitationNotification(BaseModel):
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
 
@@ -1656,6 +1644,10 @@ class FileSystemCapabilities(BaseModel):
         return use_default_on_error(v, handler, info)
 
 
+class CompactionCapabilities(BaseModel):
+    pass
+
+
 class BooleanConfigOptionCapabilities(BaseModel):
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
@@ -1683,7 +1675,9 @@ class AuthCapabilities(BaseModel):
     """
     Whether the client supports `terminal` authentication methods.
 
-    When `true`, the agent may include `terminal` entries in its authentication methods.
+    The client should set this to `true` only when it can reproduce the
+    configured agent invocation in an interactive terminal. When `true`, the
+    agent may include `terminal` entries in its authentication methods.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
@@ -1707,6 +1701,8 @@ class ElicitationFormCapabilities(BaseModel):
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
 
@@ -1717,6 +1713,8 @@ class ElicitationUrlCapabilities(BaseModel):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -2354,6 +2352,8 @@ class DeclineElicitationResponse(BaseModel):
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
     action: Literal["decline"] = "decline"
@@ -2365,6 +2365,8 @@ class CancelElicitationResponse(BaseModel):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -2380,6 +2382,8 @@ class OtherElicitationResponse(BaseModel):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -2875,6 +2879,8 @@ class CreateUrlSessionElicitationRequest(CreateUrlSessionElicitationRequestBase,
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
     mode: Literal["url"] = "url"
@@ -2890,6 +2896,8 @@ class CreateUrlRequestElicitationRequest(CreateUrlRequestElicitationRequestBase,
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -2909,6 +2917,8 @@ class CreateOtherSessionElicitationRequest(ElicitationSessionScope):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -2935,6 +2945,8 @@ class CreateOtherRequestElicitationRequest(ElicitationRequestScope):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -2972,18 +2984,26 @@ class MultiSelectPropertySchema(BaseModel):
     title: Optional[str] = None
     """
     Optional title for the property.
+
+    Optional. Omitted and `null` are equivalent and mean no title is provided.
     """
     description: Optional[str] = None
     """
     Human-readable description.
+
+    Optional. Omitted and `null` are equivalent and mean no description is provided.
     """
     min_items: Annotated[Optional[int], Field(alias="minItems", ge=0)] = None
     """
     Minimum number of items to select.
+
+    Optional. Omitted and `null` are equivalent and mean there is no minimum selection count.
     """
     max_items: Annotated[Optional[int], Field(alias="maxItems", ge=0)] = None
     """
     Maximum number of items to select.
+
+    Optional. Omitted and `null` are equivalent and mean there is no maximum selection count.
     """
     items: Union[StringMultiSelectItems, OtherMultiSelectItems, TitledMultiSelectItems]
     """
@@ -2992,12 +3012,16 @@ class MultiSelectPropertySchema(BaseModel):
     default: Optional[List[str]] = None
     """
     Default selected values.
+
+    Optional. Omitted and `null` are equivalent and mean no default selections are provided.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -3202,11 +3226,7 @@ class NesContextCapabilities(BaseModel):
         return use_default_on_error(v, handler, info)
 
 
-class EnvVarAuthMethod(AuthMethodEnvVar):
-    type: Literal["env_var"] = "env_var"
-
-
-class TerminalAuthMethod(AuthMethodTerminal):
+class EnvVarAuthMethod(AuthMethodTerminal):
     type: Literal["terminal"] = "terminal"
 
 
@@ -3597,8 +3617,8 @@ class ElicitationCapabilities(BaseModel):
     """
     Whether the client supports form-based elicitation.
 
-    Optional. Omitted or `null` both mean the client does not advertise support.
-    Supplying `{}` means the client supports form-based elicitation.
+    Optional. Omitted and `null` are equivalent and mean form support is not advertised.
+    Supplying `{}` explicitly advertises form support.
     """
     url: Optional[ElicitationUrlCapabilities] = None
     """
@@ -3612,6 +3632,8 @@ class ElicitationCapabilities(BaseModel):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -3933,6 +3955,8 @@ class AcceptElicitationResponse(ElicitationAcceptAction):
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -4283,7 +4307,82 @@ class AvailableCommandsUpdateBase(BaseModel):
     """
 
 
+class CompactionUpdate(BaseModel):
+    compaction_id: Annotated[str, Field(alias="compactionId")]
+    """
+    The Agent-owned ID of this compaction, unique within the session.
+    """
+    status: Union[Literal["in_progress"], Literal["completed"], Literal["failed"], Literal["cancelled"], str]
+    """
+    Current lifecycle status.
+    """
+    summary: Optional[
+        List[
+            Annotated[
+                Union[
+                    TextContentBlock,
+                    ImageContentBlock,
+                    AudioContentBlock,
+                    ResourceContentBlock,
+                    EmbeddedResourceContentBlock,
+                ],
+                Field(discriminator="type"),
+            ]
+        ]
+    ] = None
+    """
+    Complete replacement user-displayable summary retained by the compaction.
+    """
+    error: Optional[str] = None
+    """
+    Human-readable description of why the compaction failed.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    Extensible metadata patch for this compaction.
+    """
+
+    @field_validator("error", mode="wrap")
+    @classmethod
+    def use_default_on_error_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
+        return use_default_on_error(v, handler, info)
+
+    @field_validator("summary", mode="wrap")
+    @classmethod
+    def skip_invalid_items_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
+        return skip_invalid_items(v, handler, info)
+
+
+class CompactionSummaryChunk(BaseModel):
+    compaction_id: Annotated[str, Field(alias="compactionId")]
+    """
+    ID of the compaction whose summary receives this content.
+    """
+    content: Annotated[
+        Union[
+            TextContentBlock, ImageContentBlock, AudioContentBlock, ResourceContentBlock, EmbeddedResourceContentBlock
+        ],
+        Field(discriminator="type"),
+    ]
+    """
+    One content block to append.
+    """
+    field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
+    """
+    Metadata scoped to this chunk. Omission and `null` both mean absent.
+    """
+
+
 class ClientSessionCapabilities(BaseModel):
+    compaction: Optional[CompactionCapabilities] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Support for ID-addressed context compaction updates. Omitted or `null`
+    means unsupported; `{}` advertises the complete compaction contract.
+    """
     config_options: Annotated[Optional[SessionConfigOptionsCapabilities], Field(alias="configOptions")] = None
     """
     Config option capabilities supported by the client.
@@ -4300,7 +4399,7 @@ class ClientSessionCapabilities(BaseModel):
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
 
-    @field_validator("config_options", mode="wrap")
+    @field_validator("compaction", "config_options", mode="wrap")
     @classmethod
     def use_default_on_error_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
         return use_default_on_error(v, handler, info)
@@ -4476,6 +4575,8 @@ class ElicitationSchema(BaseModel):
     title: Optional[str] = None
     """
     Optional title for the schema.
+
+    Optional. Omitted and `null` are equivalent and mean no title is provided.
     """
     properties: Annotated[
         Optional[
@@ -4499,16 +4600,22 @@ class ElicitationSchema(BaseModel):
     required: Optional[List[str]] = None
     """
     List of required property names.
+
+    Optional. Omitted and `null` are equivalent and mean no property names are required.
     """
     description: Optional[str] = None
     """
     Optional description of what this schema represents.
+
+    Optional. Omitted and `null` are equivalent and mean no schema description is provided.
     """
     field_meta: Annotated[Optional[Dict[str, Any]], Field(alias="_meta")] = None
     """
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -4536,10 +4643,6 @@ class ElicitationFormRequestMode(ElicitationRequestScope):
 class ElicitationFormMode(RootModel[Union[ElicitationFormSessionMode, ElicitationFormRequestMode]]):
     root: Union[ElicitationFormSessionMode, ElicitationFormRequestMode]
     """
-    **UNSTABLE**
-
-    This capability is not part of the spec yet, and may be removed or changed at any point.
-
     Form-based elicitation mode where the client renders a form from the provided schema.
     """
 
@@ -4760,6 +4863,16 @@ class AvailableCommandsUpdate(AvailableCommandsUpdateBase):
         return skip_invalid_items(v, handler, info)
 
 
+class SessionUpdateCompactionUpdate(CompactionUpdate):
+    session_update: Annotated[Literal["compaction_update"], Field(alias="sessionUpdate")] = "compaction_update"
+
+
+class SessionUpdateCompactionSummaryChunk(CompactionSummaryChunk):
+    session_update: Annotated[Literal["compaction_summary_chunk"], Field(alias="sessionUpdate")] = (
+        "compaction_summary_chunk"
+    )
+
+
 class ToolCall(BaseModel):
     tool_call_id: Annotated[str, Field(alias="toolCallId")]
     """
@@ -4768,6 +4881,17 @@ class ToolCall(BaseModel):
     title: str
     """
     Human-readable title describing what the tool is doing.
+    """
+    name: Optional[str] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Programmatic name of the tool being invoked.
+
+    This field is optional. Omitting it or sending `null` both mean that no
+    tool name is available.
     """
     kind: Optional[
         Literal["read", "edit", "delete", "move", "search", "execute", "think", "fetch", "switch_mode", "other"]
@@ -4813,7 +4937,7 @@ class ToolCall(BaseModel):
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
 
-    @field_validator("kind", "raw_input", "raw_output", "status", mode="wrap")
+    @field_validator("kind", "name", "raw_input", "raw_output", "status", mode="wrap")
     @classmethod
     def use_default_on_error_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
         return use_default_on_error(v, handler, info)
@@ -4875,20 +4999,12 @@ class ClientCapabilities(BaseModel):
     """
     auth: Annotated[Optional[AuthCapabilities], Field(validate_default=True)] = {"terminal": False}
     """
-    **UNSTABLE**
-
-    This capability is not part of the spec yet, and may be removed or changed at any point.
-
     Authentication capabilities supported by the client.
     Determines which authentication method types the agent may include
     in its `InitializeResponse`.
     """
     elicitation: Optional[ElicitationCapabilities] = None
     """
-    **UNSTABLE**
-
-    This capability is not part of the spec yet, and may be removed or changed at any point.
-
     Elicitation capabilities supported by the client.
     Determines which elicitation modes the agent may use.
 
@@ -5051,6 +5167,17 @@ class ToolCallUpdate(BaseModel):
     """
     Update the human-readable title.
     """
+    name: Optional[str] = None
+    """
+    **UNSTABLE**
+
+    This capability is not part of the spec yet, and may be removed or changed at any point.
+
+    Update the programmatic name of the tool being invoked.
+
+    This field is optional. Omitting it or sending `null` both mean that
+    the existing name is left unchanged.
+    """
     content: Optional[
         List[
             Annotated[
@@ -5083,7 +5210,7 @@ class ToolCallUpdate(BaseModel):
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
 
-    @field_validator("kind", "raw_input", "raw_output", "status", "title", mode="wrap")
+    @field_validator("kind", "name", "raw_input", "raw_output", "status", "title", mode="wrap")
     @classmethod
     def use_default_on_error_validator(cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
         return use_default_on_error(v, handler, info)
@@ -5119,6 +5246,8 @@ class CreateFormSessionElicitationRequest(CreateFormSessionElicitationRequestBas
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
 
+    Optional. Omitted and `null` are equivalent and mean no metadata.
+
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
     mode: Literal["form"] = "form"
@@ -5134,6 +5263,8 @@ class CreateFormRequestElicitationRequest(CreateFormRequestElicitationRequestBas
     The _meta property is reserved by ACP to allow clients and agents to attach additional
     metadata to their interactions. Implementations MUST NOT make assumptions about values at
     these keys.
+
+    Optional. Omitted and `null` are equivalent and mean no metadata.
 
     See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     """
@@ -5420,6 +5551,8 @@ class SessionNotification(BaseModel):
             ConfigOptionUpdate,
             SessionInfoUpdate,
             UsageUpdate,
+            SessionUpdateCompactionUpdate,
+            SessionUpdateCompactionSummaryChunk,
         ],
         Field(discriminator="session_update"),
     ]
@@ -5531,8 +5664,7 @@ class InitializeResponse(BaseModel):
     Capabilities supported by the agent.
     """
     auth_methods: Annotated[
-        Optional[List[Union[EnvVarAuthMethod, TerminalAuthMethod, AuthMethodAgent]]],
-        Field(alias="authMethods", validate_default=True),
+        Optional[List[Union[EnvVarAuthMethod, AuthMethodAgent]]], Field(alias="authMethods", validate_default=True)
     ] = []
     """
     Authentication methods supported by the agent.

--- a/tests/contrib/test_contrib_tool_calls.py
+++ b/tests/contrib/test_contrib_tool_calls.py
@@ -6,12 +6,15 @@ from acp.schema import ContentToolCallContent, TextContentBlock, ToolCallProgres
 
 def test_tool_call_tracker_generates_ids_and_updates():
     tracker = ToolCallTracker(id_factory=lambda: "generated-id")
-    start = tracker.start("external", title="Run command")
+    start = tracker.start("external", title="Run command", name="shell")
     assert start.tool_call_id == "generated-id"
-    progress = tracker.progress("external", status="completed")
+    assert start.name == "shell"
+    progress = tracker.progress("external", name="terminal", status="completed")
     assert isinstance(progress, ToolCallProgress)
     assert progress.tool_call_id == "generated-id"
+    assert progress.name == "terminal"
     view = tracker.view("external")
+    assert view.name == "terminal"
     assert view.status == "completed"
 
 

--- a/tests/golden/session_update_compaction_summary_chunk.json
+++ b/tests/golden/session_update_compaction_summary_chunk.json
@@ -1,0 +1,8 @@
+{
+  "sessionUpdate": "compaction_summary_chunk",
+  "compactionId": "compaction_001",
+  "content": {
+    "type": "text",
+    "text": "Earlier context summarized."
+  }
+}

--- a/tests/golden/session_update_compaction_update.json
+++ b/tests/golden/session_update_compaction_update.json
@@ -1,0 +1,11 @@
+{
+  "sessionUpdate": "compaction_update",
+  "compactionId": "compaction_001",
+  "status": "completed",
+  "summary": [
+    {
+      "type": "text",
+      "text": "Earlier context summarized."
+    }
+  ]
+}

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -32,6 +32,8 @@ from acp.schema import (
     RequestPermissionRequest,
     RequestPermissionResponse,
     ResourceContentBlock,
+    SessionUpdateCompactionSummaryChunk,
+    SessionUpdateCompactionUpdate,
     SetSessionConfigOptionResponse,
     SetSessionConfigOptionSelectRequest,
     TerminalToolCallContent,
@@ -69,6 +71,8 @@ GOLDEN_CASES: dict[str, type[BaseModel]] = {
     "request_permission_response_selected": RequestPermissionResponse,
     "session_update_agent_message_chunk": AgentMessageChunk,
     "session_update_agent_thought_chunk": AgentThoughtChunk,
+    "session_update_compaction_summary_chunk": SessionUpdateCompactionSummaryChunk,
+    "session_update_compaction_update": SessionUpdateCompactionUpdate,
     "session_update_config_option_update": ConfigOptionUpdate,
     "session_update_plan": AgentPlanUpdate,
     "session_update_tool_call": ToolCallStart,
@@ -154,6 +158,15 @@ MODEL_BUILDERS: dict[str, Callable[[], BaseModel]] = {
                 status="pending",
             ),
         ]
+    ),
+    "session_update_compaction_summary_chunk": lambda: SessionUpdateCompactionSummaryChunk(
+        compaction_id="compaction_001",
+        content=TextContentBlock(text="Earlier context summarized."),
+    ),
+    "session_update_compaction_update": lambda: SessionUpdateCompactionUpdate(
+        compaction_id="compaction_001",
+        status="completed",
+        summary=[TextContentBlock(text="Earlier context summarized.")],
     ),
     "session_update_tool_call": lambda: ToolCallStart(
         tool_call_id="call_001",


### PR DESCRIPTION
## Summary

- Regenerate v1 bindings from `schema-v1.21.0`, including compaction updates and tool names.
- Remove the obsolete open-union rewrite and keep signature generation idempotent.

## Related issues

None.

## Testing

- `make gen-check`
- `make check`
- `make test` (201 passed, 1 skipped)
- Ran `ACP_SCHEMA_VERSION=schema-v1.21.0 make gen-all` twice with an unchanged diff.

## Docs & screenshots

No docs or screenshots. This PR updates the generated protocol API.

## Checklist

- [x] Conventional Commit title (e.g. `feat:`, `fix:`).
- [x] Tests cover the change or are not required (explain above).
- [x] Docs/examples updated when behaviour is user-facing.
- [x] Schema regenerations (`make gen-all`) are called out if applicable.